### PR TITLE
Add 'PropertiesChanged' signal class and object path getter

### DIFF
--- a/src/main/java/org/freedesktop/DBus.java
+++ b/src/main/java/org/freedesktop/DBus.java
@@ -14,9 +14,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 import org.freedesktop.dbus.DBusInterface;
 import org.freedesktop.dbus.DBusSignal;
@@ -88,6 +87,24 @@ public interface DBus extends DBusInterface {
          * @return The properties mapped to their values.
          */
         Map<String, Variant<?>> GetAll(String interface_name);
+
+        /**
+         * Signal generated when a property changes.
+         */
+        public class PropertiesChanged extends DBusSignal {
+            public final String interfaceName;
+            public final Map<String, Variant<?>> changedProperties;
+            public final List<String> invalidatedProperties;
+
+            public PropertiesChanged(final String path, final String _interfaceName,
+                    final Map<String, Variant<?>> _changedProperties, final List<String> _invalidatedProperties)
+                    throws DBusException {
+                super(path, _interfaceName, _changedProperties, _invalidatedProperties);
+                this.interfaceName = _interfaceName;
+                this.changedProperties = _changedProperties;
+                this.invalidatedProperties = _invalidatedProperties;
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/freedesktop/dbus/AbstractConnection.java
+++ b/src/main/java/org/freedesktop/dbus/AbstractConnection.java
@@ -41,7 +41,7 @@ public abstract class AbstractConnection {
 
     protected class FallbackContainer {
         private final Logger                  logger    = LoggerFactory.getLogger(getClass());
-        private Map<String[], ExportedObject> fallbacks = new HashMap<String[], ExportedObject>();
+        private Map<String[], ExportedObject> fallbacks = new HashMap<>();
 
         public synchronized void add(String path, ExportedObject eo) {
             logger.debug("Adding fallback on " + path + " of " + eo);
@@ -169,6 +169,11 @@ public abstract class AbstractConnection {
                 return "<!DOCTYPE node PUBLIC \"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN\" " + "\"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n" + intro;
             }
         }
+
+        @Override
+        public String getObjectPath() {
+            return objectpath;
+        }
     }
 
     protected class WorkerThread extends Thread {
@@ -295,7 +300,7 @@ public abstract class AbstractConnection {
     // CHECKSTYLE:ON
     static final Pattern                                                     DOLLAR_PATTERN           = Pattern.compile("[$]");
     public static final boolean                                              EXCEPTION_DEBUG;
-    private static final Map<Thread, DBusCallInfo>                           INFOMAP                  = new HashMap<Thread, DBusCallInfo>();
+    private static final Map<Thread, DBusCallInfo>                           INFOMAP                  = new HashMap<>();
     static final boolean                                                     FLOAT_SUPPORT;
 
 
@@ -308,20 +313,20 @@ public abstract class AbstractConnection {
     }
 
     protected AbstractConnection(String address) throws DBusException {
-        exportedObjects = new HashMap<String, ExportedObject>();
-        importedObjects = new HashMap<DBusInterface, RemoteObject>();
+        exportedObjects = new HashMap<>();
+        importedObjects = new HashMap<>();
         globalHandlerReference = new GlobalHandler();
         synchronized (exportedObjects) {
             exportedObjects.put(null, new ExportedObject(globalHandlerReference, weakreferences));
         }
-        handledSignals = new HashMap<SignalTuple, Vector<DBusSigHandler<? extends DBusSignal>>>();
+        handledSignals = new HashMap<>();
         pendingCalls = new EfficientMap(PENDING_MAP_INITIAL_SIZE);
         outgoing = new EfficientQueue(PENDING_MAP_INITIAL_SIZE);
-        pendingCallbacks = new HashMap<MethodCall, CallbackHandler<? extends Object>>();
-        pendingCallbackReplys = new HashMap<MethodCall, DBusAsyncReply<? extends Object>>();
-        pendingErrors = new LinkedList<Error>();
-        runnables = new LinkedList<Runnable>();
-        workers = new LinkedList<WorkerThread>();
+        pendingCallbacks = new HashMap<>();
+        pendingCallbackReplys = new HashMap<>();
+        pendingErrors = new LinkedList<>();
+        runnables = new LinkedList<>();
+        workers = new LinkedList<>();
         objectTree = new ObjectTree();
         fallbackcontainer = new FallbackContainer();
         synchronized (workers) {
@@ -591,7 +596,7 @@ public abstract class AbstractConnection {
         synchronized (handledSignals) {
             Vector<DBusSigHandler<? extends DBusSignal>> v = handledSignals.get(key);
             if (null == v) {
-                v = new Vector<DBusSigHandler<? extends DBusSignal>>();
+                v = new Vector<>();
                 v.add(handler);
                 handledSignals.put(key, v);
             } else {
@@ -911,7 +916,7 @@ public abstract class AbstractConnection {
     })
     private void handleMessage(final DBusSignal s) {
         logger.debug("Handling incoming signal: " + s);
-        Vector<DBusSigHandler<? extends DBusSignal>> v = new Vector<DBusSigHandler<? extends DBusSignal>>();
+        Vector<DBusSigHandler<? extends DBusSignal>> v = new Vector<>();
         synchronized (handledSignals) {
             Vector<DBusSigHandler<? extends DBusSignal>> t;
             t = handledSignals.get(new SignalTuple(s.getInterface(), s.getName(), null, null));
@@ -1056,6 +1061,7 @@ public abstract class AbstractConnection {
              logger.trace("Adding Runnable for method "+fasr.getMethod()+" with callback handler "+fcbh);
              addRunnable(new Runnable() {
                 private boolean run = false;
+                @Override
                 public synchronized void run()
                 {
                    if (run) return;

--- a/src/main/java/org/freedesktop/dbus/DBusInterface.java
+++ b/src/main/java/org/freedesktop/dbus/DBusInterface.java
@@ -23,9 +23,16 @@ package org.freedesktop.dbus;
  * </p>
  */
 public interface DBusInterface {
+
     /**
     * Returns true on remote objects.
     * Local objects implementing this interface MUST return false.
     */
     boolean isRemote();
+
+    /**
+     * Returns the path of this object.
+     */
+    public String getObjectPath();
+
 }

--- a/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
+++ b/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
@@ -192,6 +192,8 @@ class RemoteInvocationHandler implements InvocationHandler {
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if (method.getName().equals("isRemote")) {
             return true;
+        } else if (method.getName().equals("getObjectPath")) {
+            return remote.objectpath;
         } else if (method.getName().equals("clone")) {
             return null;
         } else if (method.getName().equals("equals")) {

--- a/src/main/java/org/freedesktop/dbus/bin/DBusDaemon.java
+++ b/src/main/java/org/freedesktop/dbus/bin/DBusDaemon.java
@@ -95,8 +95,8 @@ public class DBusDaemon extends Thread {
         private String                name;
 
         MagicMap(String _name) {
-            m = new HashMap<A, LinkedList<B>>();
-            q = new LinkedList<A>();
+            m = new HashMap<>();
+            q = new LinkedList<>();
             this.name = _name;
         }
 
@@ -110,7 +110,7 @@ public class DBusDaemon extends Thread {
             if (m.containsKey(a)) {
                 m.get(a).add(b);
             } else {
-                LinkedList<B> l = new LinkedList<B>();
+                LinkedList<B> l = new LinkedList<>();
                 l.add(b);
                 m.put(a, l);
             }
@@ -124,7 +124,7 @@ public class DBusDaemon extends Thread {
             if (m.containsKey(a)) {
                 m.get(a).add(b);
             } else {
-                LinkedList<B> l = new LinkedList<B>();
+                LinkedList<B> l = new LinkedList<>();
                 l.add(b);
                 m.put(a, l);
             }
@@ -448,6 +448,11 @@ public class DBusDaemon extends Thread {
         }
 
         @Override
+        public String getObjectPath() {
+            return null;
+        }
+
+        @Override
         public String Introspect() {
             return "<!DOCTYPE node PUBLIC \"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN\"\n" + "\"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n" + "<node>\n" + "  <interface name=\"org.freedesktop.DBus.Introspectable\">\n" + "    <method name=\"Introspect\">\n"
                     + "      <arg name=\"data\" direction=\"out\" type=\"s\"/>\n" + "    </method>\n" + "  </interface>\n" + "  <interface name=\"org.freedesktop.DBus\">\n" + "    <method name=\"RequestName\">\n" + "      <arg direction=\"in\" type=\"s\"/>\n" + "      <arg direction=\"in\" type=\"u\"/>\n"
@@ -576,7 +581,7 @@ public class DBusDaemon extends Thread {
 
         public Reader(Connstruct _conn) {
             this.conn = _conn;
-            weakconn = new WeakReference<Connstruct>(_conn);
+            weakconn = new WeakReference<>(_conn);
             setName("Reader");
         }
 
@@ -624,12 +629,12 @@ public class DBusDaemon extends Thread {
         }
     }
 
-    private Map<Connstruct, Reader>                      conns       = new HashMap<Connstruct, Reader>();
-    private HashMap<String, Connstruct>                  names       = new HashMap<String, Connstruct>();
-    private MagicMap<Message, WeakReference<Connstruct>> outqueue    = new MagicMap<Message, WeakReference<Connstruct>>("out");
-    private MagicMap<Message, WeakReference<Connstruct>> inqueue     = new MagicMap<Message, WeakReference<Connstruct>>("in");
-    private MagicMap<Message, WeakReference<Connstruct>> localqueue  = new MagicMap<Message, WeakReference<Connstruct>>("local");
-    private List<Connstruct>                             sigrecips   = new Vector<Connstruct>();
+    private Map<Connstruct, Reader>                      conns       = new HashMap<>();
+    private HashMap<String, Connstruct>                  names       = new HashMap<>();
+    private MagicMap<Message, WeakReference<Connstruct>> outqueue    = new MagicMap<>("out");
+    private MagicMap<Message, WeakReference<Connstruct>> inqueue     = new MagicMap<>("in");
+    private MagicMap<Message, WeakReference<Connstruct>> localqueue  = new MagicMap<>("local");
+    private List<Connstruct>                             sigrecips   = new Vector<>();
     private boolean                                      run        = true;
     private int                                          nextUnique = 0;
     private Object                                       uniqueLock = new Object();
@@ -664,9 +669,9 @@ public class DBusDaemon extends Thread {
                 synchronized (outqueue) {
                     for (Connstruct d : conns.keySet()) {
                         if (head) {
-                            outqueue.putFirst(m, new WeakReference<Connstruct>(d));
+                            outqueue.putFirst(m, new WeakReference<>(d));
                         } else {
-                            outqueue.putLast(m, new WeakReference<Connstruct>(d));
+                            outqueue.putLast(m, new WeakReference<>(d));
                         }
                     }
                     outqueue.notifyAll();
@@ -675,9 +680,9 @@ public class DBusDaemon extends Thread {
         } else {
             synchronized (outqueue) {
                 if (head) {
-                    outqueue.putFirst(m, new WeakReference<Connstruct>(c));
+                    outqueue.putFirst(m, new WeakReference<>(c));
                 } else {
-                    outqueue.putLast(m, new WeakReference<Connstruct>(c));
+                    outqueue.putLast(m, new WeakReference<>(c));
                 }
                 outqueue.notifyAll();
             }
@@ -693,7 +698,7 @@ public class DBusDaemon extends Thread {
 
         List<Connstruct> l;
         synchronized (sigrecips) {
-            l = new Vector<Connstruct>(sigrecips);
+            l = new Vector<>(sigrecips);
         }
 
         LOGGER.debug("exit");
@@ -802,7 +807,7 @@ public class DBusDaemon extends Thread {
             } catch (IOException exIo) {
             }
             synchronized (names) {
-                List<String> toRemove = new Vector<String>();
+                List<String> toRemove = new Vector<>();
                 for (String name : names.keySet()) {
                     if (names.get(name) == c) {
                         toRemove.add(name);

--- a/src/test/java/org/freedesktop/dbus/test/CrossTestClient.java
+++ b/src/test/java/org/freedesktop/dbus/test/CrossTestClient.java
@@ -44,15 +44,15 @@ public class CrossTestClient implements DBus.Binding.TestClient, DBusSigHandler<
     private static final Logger              LOGGER = LoggerFactory.getLogger(CrossTestClient.class);
 
     private DBusConnection                   conn;
-    public static final Set<String>               PASSED = new TreeSet<String>();
-    public static final Map<String, List<String>> FAILED = new HashMap<String, List<String>>();
+    public static final Set<String>               PASSED = new TreeSet<>();
+    public static final Map<String, List<String>> FAILED = new HashMap<>();
 
     private static CrossTestClient         CROSS_TEST_CLIENT_INSTANCE;
     static {
-        List<String> l = new Vector<String>();
+        List<String> l = new Vector<>();
         l.add("Signal never arrived");
         FAILED.put("org.freedesktop.DBus.Binding.TestSignals.Triggered", l);
-        l = new Vector<String>();
+        l = new Vector<>();
         l.add("Method never called");
         FAILED.put("org.freedesktop.DBus.Binding.TestClient.Response", l);
     }
@@ -64,6 +64,11 @@ public class CrossTestClient implements DBus.Binding.TestClient, DBusSigHandler<
     @Override
     public boolean isRemote() {
         return false;
+    }
+
+    @Override
+    public String getObjectPath() {
+        return null;
     }
 
     @Override
@@ -96,7 +101,7 @@ public class CrossTestClient implements DBus.Binding.TestClient, DBusSigHandler<
         test = test.replaceAll("[$]", ".");
         List<String> reasons = FAILED.get(test);
         if (null == reasons) {
-            reasons = new Vector<String>();
+            reasons = new Vector<>();
             FAILED.put(test, reasons);
         }
         reasons.add(reason);
@@ -219,7 +224,7 @@ public class CrossTestClient implements DBus.Binding.TestClient, DBusSigHandler<
 
     @SuppressWarnings("unchecked")
     public static List<Variant<Object>> primitizeRecurse(Object a, Type t) {
-        List<Variant<Object>> vs = new Vector<Variant<Object>>();
+        List<Variant<Object>> vs = new Vector<>();
         if (t instanceof ParameterizedType) {
             Class<Object> c = (Class<Object>) ((ParameterizedType) t).getRawType();
             if (List.class.isAssignableFrom(c)) {
@@ -272,7 +277,7 @@ public class CrossTestClient implements DBus.Binding.TestClient, DBusSigHandler<
     }
 
     public static void primitizeTest(DBus.Binding.Tests tests, Object input) {
-        Variant<Object> in = new Variant<Object>(input);
+        Variant<Object> in = new Variant<>(input);
         List<Variant<Object>> vs = primitize(in);
         List<Variant<Object>> res;
 
@@ -322,8 +327,8 @@ public class CrossTestClient implements DBus.Binding.TestClient, DBusSigHandler<
             fail("org.freedesktop.DBus.Introspectable.Introspect", "Got exception during introspection on / (" + dbee.getClass().getName() + "): " + dbee.getMessage());
         }
 
-        test(DBus.Binding.Tests.class, tests, "Identity", new Variant<Integer>(new Integer(1)), new Variant<Integer>(new Integer(1)));
-        test(DBus.Binding.Tests.class, tests, "Identity", new Variant<String>("Hello"), new Variant<String>("Hello"));
+        test(DBus.Binding.Tests.class, tests, "Identity", new Variant<>(new Integer(1)), new Variant<>(new Integer(1)));
+        test(DBus.Binding.Tests.class, tests, "Identity", new Variant<>("Hello"), new Variant<>("Hello"));
 
         test(DBus.Binding.Tests.class, tests, "IdentityBool", false, false);
         test(DBus.Binding.Tests.class, tests, "IdentityBool", true, true);
@@ -407,7 +412,7 @@ public class CrossTestClient implements DBus.Binding.TestClient, DBusSigHandler<
         testArray(DBus.Binding.Tests.class, tests, "IdentityInt64Array", Long.TYPE, null);
         testArray(DBus.Binding.Tests.class, tests, "IdentityDoubleArray", Double.TYPE, null);
 
-        testArray(DBus.Binding.Tests.class, tests, "IdentityArray", Variant.class, new Variant<String>("aoeu"));
+        testArray(DBus.Binding.Tests.class, tests, "IdentityArray", Variant.class, new Variant<>("aoeu"));
         testArray(DBus.Binding.Tests.class, tests, "IdentityUInt16Array", UInt16.class, new UInt16(12));
         testArray(DBus.Binding.Tests.class, tests, "IdentityUInt32Array", UInt32.class, new UInt32(190));
         testArray(DBus.Binding.Tests.class, tests, "IdentityUInt64Array", UInt64.class, new UInt64(103948));
@@ -438,31 +443,31 @@ public class CrossTestClient implements DBus.Binding.TestClient, DBusSigHandler<
         }
         test(DBus.Binding.SingleTests.class, singletests, "Sum", new UInt32(res % (UInt32.MAX_VALUE + 1)), bs);
 
-        test(DBus.Binding.Tests.class, tests, "DeStruct", new DBus.Binding.Triplet<String, UInt32, Short>("hi", new UInt32(12), new Short((short) 99)), new DBus.Binding.TestStruct("hi", new UInt32(12), new Short((short) 99)));
+        test(DBus.Binding.Tests.class, tests, "DeStruct", new DBus.Binding.Triplet<>("hi", new UInt32(12), new Short((short) 99)), new DBus.Binding.TestStruct("hi", new UInt32(12), new Short((short) 99)));
 
-        Map<String, String> in = new HashMap<String, String>();
-        Map<String, List<String>> out = new HashMap<String, List<String>>();
+        Map<String, String> in = new HashMap<>();
+        Map<String, List<String>> out = new HashMap<>();
         test(DBus.Binding.Tests.class, tests, "InvertMapping", out, in);
 
         in.put("hi", "there");
         in.put("to", "there");
         in.put("from", "here");
         in.put("in", "out");
-        List<String> l = new Vector<String>();
+        List<String> l = new Vector<>();
         l.add("hi");
         l.add("to");
         out.put("there", l);
-        l = new Vector<String>();
+        l = new Vector<>();
         l.add("from");
         out.put("here", l);
-        l = new Vector<String>();
+        l = new Vector<>();
         l.add("in");
         out.put("out", l);
         test(DBus.Binding.Tests.class, tests, "InvertMapping", out, in);
 
         primitizeTest(tests, new Integer(1));
-        primitizeTest(tests, new Variant<Variant<Variant<Variant<String>>>>(new Variant<Variant<Variant<String>>>(new Variant<Variant<String>>(new Variant<String>("Hi")))));
-        primitizeTest(tests, new Variant<Map<String, String>>(in, new DBusMapType(String.class, String.class)));
+        primitizeTest(tests, new Variant<>(new Variant<>(new Variant<>(new Variant<>("Hi")))));
+        primitizeTest(tests, new Variant<>(in, new DBusMapType(String.class, String.class)));
 
         test(DBus.Binding.Tests.class, tests, "Trigger", null, "/Test", new UInt64(21389479283L));
 

--- a/src/test/java/org/freedesktop/dbus/test/CrossTestServer.java
+++ b/src/test/java/org/freedesktop/dbus/test/CrossTestServer.java
@@ -30,8 +30,8 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException;
 public class CrossTestServer implements DBus.Binding.Tests, DBus.Binding.SingleTests, DBusSigHandler<DBus.Binding.TestClient.Trigger> {
     private DBusConnection conn;
     private boolean                run     = true;
-    private Set<String>    done    = new TreeSet<String>();
-    private Set<String>    notdone = new TreeSet<String>();
+    private Set<String>    done    = new TreeSet<>();
+    private Set<String>    notdone = new TreeSet<>();
     {
         notdone.add("org.freedesktop.DBus.Binding.Tests.Identity");
         notdone.add("org.freedesktop.DBus.Binding.Tests.IdentityByte");
@@ -73,6 +73,11 @@ public class CrossTestServer implements DBus.Binding.Tests, DBus.Binding.SingleT
     @Override
     public boolean isRemote() {
         return false;
+    }
+
+    @Override
+    public String getObjectPath() {
+        return null;
     }
 
     public boolean isRun() {
@@ -304,12 +309,12 @@ public class CrossTestServer implements DBus.Binding.Tests, DBus.Binding.SingleT
     public Map<String, List<String>> InvertMapping(Map<String, String> a) {
         done.add("org.freedesktop.DBus.Binding.Tests.InvertMapping");
         notdone.remove("org.freedesktop.DBus.Binding.Tests.InvertMapping");
-        HashMap<String, List<String>> m = new HashMap<String, List<String>>();
+        HashMap<String, List<String>> m = new HashMap<>();
         for (String s : a.keySet()) {
             String b = a.get(s);
             List<String> l = m.get(b);
             if (null == l) {
-                l = new Vector<String>();
+                l = new Vector<>();
                 m.put(b, l);
             }
             l.add(s);
@@ -322,7 +327,7 @@ public class CrossTestServer implements DBus.Binding.Tests, DBus.Binding.SingleT
     public DBus.Binding.Triplet<String, UInt32, Short> DeStruct(DBus.Binding.TestStruct a) {
         done.add("org.freedesktop.DBus.Binding.Tests.DeStruct");
         notdone.remove("org.freedesktop.DBus.Binding.Tests.DeStruct");
-        return new DBus.Binding.Triplet<String, UInt32, Short>(a.a, a.b, a.c);
+        return new DBus.Binding.Triplet<>(a.a, a.b, a.c);
     }
 
     @Override

--- a/src/test/java/org/freedesktop/dbus/test/P2pTestServer.java
+++ b/src/test/java/org/freedesktop/dbus/test/P2pTestServer.java
@@ -100,6 +100,11 @@ public class P2pTestServer implements TestRemoteInterface {
     }
 
     @Override
+    public String getObjectPath() {
+        return null;
+    }
+
+    @Override
     public float testfloat(float[] f) {
         System.out.println("got float: " + Arrays.toString(f));
         return f[0];

--- a/src/test/java/org/freedesktop/dbus/test/ProfilerInstance.java
+++ b/src/test/java/org/freedesktop/dbus/test/ProfilerInstance.java
@@ -20,6 +20,11 @@ public class ProfilerInstance implements Profiler {
     }
 
     @Override
+    public String getObjectPath() {
+        return null;
+    }
+
+    @Override
     public void array(int[] v) {
         return;
     }

--- a/src/test/java/org/freedesktop/dbus/test/TestAll.java
+++ b/src/test/java/org/freedesktop/dbus/test/TestAll.java
@@ -54,6 +54,11 @@ class TestNewClass implements TestNewInterface {
     }
 
     @Override
+    public String getObjectPath() {
+        return null;
+    }
+
+    @Override
     public String getName() {
         return toString();
     }
@@ -116,9 +121,9 @@ class TestClass implements TestRemoteInterface, TestRemoteInterface2, TestSignal
             TestAll.fail("show received the wrong arguments");
         }
         DBusCallInfo info = AbstractConnection.getCallInfo();
-        List<Integer> l = new Vector<Integer>();
+        List<Integer> l = new Vector<>();
         l.add(1953);
-        return new TestTuple<String, List<Integer>, Boolean>(info.getSource(), l, true);
+        return new TestTuple<>(info.getSource(), l, true);
     }
 
     @Override
@@ -136,6 +141,11 @@ class TestClass implements TestRemoteInterface, TestRemoteInterface2, TestSignal
     @Override
     public boolean isRemote() {
         return false;
+    }
+
+    @Override
+    public String getObjectPath() {
+        return null;
     }
 
     /** The method we are exporting to the Bus. */
@@ -162,7 +172,7 @@ class TestClass implements TestRemoteInterface, TestRemoteInterface2, TestSignal
         if (ls.length != 4 || ls[0] != 2 || ls[1] != 6 || ls[2] != 8 || ls[3] != 12) {
             TestAll.fail("sampleArray, Integer array contents incorrect");
         }
-        Vector<Integer> v = new Vector<Integer>();
+        Vector<Integer> v = new Vector<>();
         v.add(-1);
         v.add(-5);
         v.add(-7);
@@ -343,7 +353,7 @@ class TestClass implements TestRemoteInterface, TestRemoteInterface2, TestSignal
 
     @Override
     public Map<String, Variant<?>> GetAll(String interface_name) {
-        return new HashMap<String, Variant<?>>();
+        return new HashMap<>();
     }
 
     @Override
@@ -631,7 +641,7 @@ public class TestAll {
                 clientconn.addSigHandler(TestSignalInterface.TestArraySignal.class, source, peer, new ArraySignalHandler());
                 clientconn.addSigHandler(TestSignalInterface.TestObjectSignal.class, new ObjectSignalHandler());
                 clientconn.addSigHandler(TestSignalInterface.TestPathSignal.class, new PathSignalHandler());
-                BadArraySignalHandler<TestSignalInterface.TestSignal> bash = new BadArraySignalHandler<TestSignalInterface.TestSignal>();
+                BadArraySignalHandler<TestSignalInterface.TestSignal> bash = new BadArraySignalHandler<>();
                 clientconn.addSigHandler(TestSignalInterface.TestSignal.class, bash);
                 clientconn.removeSigHandler(TestSignalInterface.TestSignal.class, bash);
                 System.out.println("done");
@@ -719,14 +729,14 @@ public class TestAll {
             if (!path.equals(p)) {
                 fail("pathrv incorrect");
             }
-            List<Path> paths = new Vector<Path>();
+            List<Path> paths = new Vector<>();
             paths.add(path);
             List<Path> ps = tri.pathlistrv(paths);
             System.out.println(paths.toString() + " => " + ps.toString());
             if (!paths.equals(ps)) {
                 fail("pathlistrv incorrect");
             }
-            Map<Path, Path> pathm = new HashMap<Path, Path>();
+            Map<Path, Path> pathm = new HashMap<>();
             pathm.put(path, path);
             Map<Path, Path> pm = tri.pathmaprv(pathm);
             System.out.println(pathm.toString() + " => " + pm.toString());
@@ -757,15 +767,15 @@ public class TestAll {
                 fail("testfloat returned the wrong thing");
             }
             System.out.println("Structs of Structs");
-            List<List<Integer>> lli = new Vector<List<Integer>>();
-            List<Integer> li = new Vector<Integer>();
+            List<List<Integer>> lli = new Vector<>();
+            List<Integer> li = new Vector<>();
             li.add(1);
             li.add(2);
             li.add(3);
             lli.add(li);
             lli.add(li);
             lli.add(li);
-            TestStruct3 ts3 = new TestStruct3(new TestStruct2(new Vector<String>(), new Variant<Integer>(0)), lli);
+            TestStruct3 ts3 = new TestStruct3(new TestStruct2(new Vector<String>(), new Variant<>(0)), lli);
             int[][] out = tri.teststructstruct(ts3);
             if (out.length != 3) {
                 fail("teststructstruct returned the wrong thing: " + Arrays.deepToString(out));
@@ -777,15 +787,15 @@ public class TestAll {
             }
 
             System.out.println("frobnicating");
-            List<Long> ls = new Vector<Long>();
+            List<Long> ls = new Vector<>();
             ls.add(2L);
             ls.add(5L);
             ls.add(71L);
-            Map<UInt16, Short> mus = new HashMap<UInt16, Short>();
+            Map<UInt16, Short> mus = new HashMap<>();
             mus.put(new UInt16(4), (short) 5);
             mus.put(new UInt16(5), (short) 6);
             mus.put(new UInt16(6), (short) 7);
-            Map<String, Map<UInt16, Short>> msmus = new HashMap<String, Map<UInt16, Short>>();
+            Map<String, Map<UInt16, Short>> msmus = new HashMap<>();
             msmus.put("stuff", mus);
             int rint = tri.frobnicate(ls, msmus, 13);
             if (-5 != rint) {
@@ -810,7 +820,7 @@ public class TestAll {
             }
 
             /* Test type signatures */
-            Vector<Type> ts = new Vector<Type>();
+            Vector<Type> ts = new Vector<>();
             Marshalling.getJavaType("ya{si}", ts, -1);
             tri.sig(ts.toArray(new Type[0]));
 
@@ -884,14 +894,14 @@ public class TestAll {
             }
 
             System.out.println("Doing stuff asynchronously");
-            DBusAsyncReply<Boolean> stuffreply = (DBusAsyncReply<Boolean>) clientconn.callMethodAsync(tri2, "dostuff", new TestStruct("bar", new UInt32(52), new Variant<Boolean>(new Boolean(true))));
+            DBusAsyncReply<Boolean> stuffreply = (DBusAsyncReply<Boolean>) clientconn.callMethodAsync(tri2, "dostuff", new TestStruct("bar", new UInt32(52), new Variant<>(new Boolean(true))));
 
             System.out.println("Checking bools");
             if (tri2.check()) {
                 fail("bools are broken");
             }
 
-            List<String> l = new Vector<String>();
+            List<String> l = new Vector<>();
             l.add("hi");
             l.add("hello");
             l.add("hej");
@@ -924,21 +934,21 @@ public class TestAll {
 
             System.out.print("Sending Array Signal...");
             /** This creates an instance of the Test Signal, with the given object path, signal name and parameters, and broadcasts in on the Bus. */
-            List<TestStruct2> tsl = new Vector<TestStruct2>();
-            tsl.add(new TestStruct2(l, new Variant<UInt64>(new UInt64(567))));
-            Map<UInt32, TestStruct2> tsm = new HashMap<UInt32, TestStruct2>();
-            tsm.put(new UInt32(1), new TestStruct2(l, new Variant<UInt64>(new UInt64(678))));
-            tsm.put(new UInt32(42), new TestStruct2(l, new Variant<UInt64>(new UInt64(789))));
+            List<TestStruct2> tsl = new Vector<>();
+            tsl.add(new TestStruct2(l, new Variant<>(new UInt64(567))));
+            Map<UInt32, TestStruct2> tsm = new HashMap<>();
+            tsm.put(new UInt32(1), new TestStruct2(l, new Variant<>(new UInt64(678))));
+            tsm.put(new UInt32(42), new TestStruct2(l, new Variant<>(new UInt64(789))));
             serverconn.sendSignal(new TestSignalInterface.TestArraySignal("/Test", tsl, tsm));
 
             System.out.println("done");
 
             System.out.print("testing custom serialization...");
-            Vector<Integer> v = new Vector<Integer>();
+            Vector<Integer> v = new Vector<>();
             v.add(1);
             v.add(2);
             v.add(3);
-            TestSerializable<String> s = new TestSerializable<String>(1, "woo", v);
+            TestSerializable<String> s = new TestSerializable<>(1, "woo", v);
             s = tri2.testSerializable((byte) 12, s, 13);
             System.out.print("returned: " + s);
             if (s.getInt() != 1 || !s.getString().equals("woo") || s.getVector().size() != 3 || s.getVector().get(0) != 1 || s.getVector().get(1) != 2 || s.getVector().get(2) != 3) {
@@ -986,8 +996,8 @@ public class TestAll {
             System.out.println("done");
 
             System.out.print("Testing nested lists...");
-            lli = new Vector<List<Integer>>();
-            li = new Vector<Integer>();
+            lli = new Vector<>();
+            li = new Vector<>();
             li.add(1);
             lli.add(li);
             List<List<Integer>> reti = tri2.checklist(lli);

--- a/src/test/java/org/freedesktop/dbus/test/TwoPartTestClient.java
+++ b/src/test/java/org/freedesktop/dbus/test/TwoPartTestClient.java
@@ -25,6 +25,11 @@ public final class TwoPartTestClient {
         }
 
         @Override
+        public String getObjectPath() {
+            return null;
+        }
+
+        @Override
         public String getName() {
             System.out.println("client name");
             return toString();

--- a/src/test/java/org/freedesktop/dbus/test/TwoPartTestServer.java
+++ b/src/test/java/org/freedesktop/dbus/test/TwoPartTestServer.java
@@ -21,6 +21,11 @@ public class TwoPartTestServer implements TwoPartInterface, DBusSigHandler<TwoPa
         }
 
         @Override
+        public String getObjectPath() {
+            return null;
+        }
+
+        @Override
         public String getName() {
             System.out.println("give name");
             return toString();
@@ -36,6 +41,11 @@ public class TwoPartTestServer implements TwoPartInterface, DBusSigHandler<TwoPa
     @Override
     public boolean isRemote() {
         return false;
+    }
+
+    @Override
+    public String getObjectPath() {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
This adds a new (missing) signal class `PropertiesChanged` and an interface method `String getObjectPath()` on interface `DBusInterface`.

My project https://github.com/thjomnx/java-systemd relies on these features.

The feature has been introduced in another repository (see here: https://github.com/mjscosta/dbus-java/commit/3688186e1c158e105e7c874a8c6fa90c850e7212) but since your artifact has made it into Maven Central I'd like to add it here. I also appreciate the changes you applied - I was about to do the same but... lack of time.

Additionally the commit contains Java 1.7 related auto-formatting changes (use of diamond operator).