### PR TITLE
Add simple support for session dbus environment variable under MacOS

### DIFF
--- a/src/main/java/org/freedesktop/dbus/DBusConnection.java
+++ b/src/main/java/org/freedesktop/dbus/DBusConnection.java
@@ -276,7 +276,15 @@ public final class DBusConnection extends AbstractConnection {
                 }
                 break;
             case SESSION:
-                s = System.getenv("DBUS_SESSION_BUS_ADDRESS");
+                // MacOS support: e.g DBUS_LAUNCHD_SESSION_BUS_SOCKET=/private/tmp/com.apple.launchd.4ojrKe6laI/unix_domain_listener
+                s = System.getenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET");
+                if (s != null) {
+                    s = "unix:path=" + s;
+                }
+                // default
+                if (s == null) {
+                    s = System.getenv("DBUS_SESSION_BUS_ADDRESS");
+                }
                 if (null == s) {
                     // address gets stashed in $HOME/.dbus/session-bus/`dbus-uuidgen --get`-`sed 's/:\(.\)\..*/\1/' <<< $DISPLAY`
                     String display = System.getenv("DISPLAY");


### PR DESCRIPTION
DBus/MacOS uses a different environment variable by default and the value is also a little bit different. Would be possible to fix this by setting the original env var depending on the Mac env var, e.g.

```
DBUS_SESSION_BUS_ADDRESS=unix:path=$DBUS_LAUNCHD_SESSION_BUS_SOCKET
```

But would be nicer if dbus-java would support that different format out of the box.