### PR TITLE
fixed Marshalling.getJavaType

### DIFF
--- a/src/main/java/org/freedesktop/dbus/Marshalling.java
+++ b/src/main/java/org/freedesktop/dbus/Marshalling.java
@@ -344,7 +344,7 @@ public final class Marshalling {
                     List<Type> contained = new ArrayList<>();
                     int c = getJavaType(dbus.substring(i + 1, j - 1), contained, -1);
                     rv.add(new DBusStructType(contained.toArray(new Type[0])));
-                    i = j;
+                    i = j-1; //-1 because j already points to the next signature char
                     break;
                 case Message.ArgumentType.ARRAY:
                     if (Message.ArgumentType.DICT_ENTRY1 == dbus.charAt(i + 1)) {

--- a/src/test/java/org/freedesktop/dbus/test/SignatureParserTest.java
+++ b/src/test/java/org/freedesktop/dbus/test/SignatureParserTest.java
@@ -1,0 +1,36 @@
+package org.freedesktop.dbus.test;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import org.freedesktop.dbus.Marshalling;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.types.DBusListType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the Marshaller.getJavaType() method.
+ *
+ * @author mdo
+ */
+public final class SignatureParserTest
+{
+  @Test
+  public void parse_complex_message_returns_correct_types() throws DBusException {
+    List<Type> temp = new ArrayList<>();
+    Marshalling.getJavaType("a(oa{sv})ao", temp, -1);
+
+    Assertions.assertEquals(2, temp.size(), "result must contain two types");
+    Assertions.assertTrue(temp.get(0) instanceof DBusListType);
+    Assertions.assertTrue(temp.get(1) instanceof DBusListType);
+  }
+
+  @Test
+  public void parse_struct_returns_correct_number_of_chars_parsed() throws Exception {
+    List<Type> temp = new ArrayList<>();
+    int parsedCharsCount = Marshalling.getJavaType("(oa{sv})ao", temp, 1);
+
+    Assertions.assertEquals(8, parsedCharsCount);
+  }
+}


### PR DESCRIPTION
fixed Marshalling.getJavaType to return correct number of parsed characters when parsing a struct. This should fix the problem #21 