### PR TITLE
Changed verbose logging of written messages to debug level

### DIFF
--- a/src/main/java/org/freedesktop/dbus/MessageWriter.java
+++ b/src/main/java/org/freedesktop/dbus/MessageWriter.java
@@ -44,7 +44,7 @@ public class MessageWriter implements Closeable {
     }
 
     public void writeMessage(Message m) throws IOException {
-        logger.info("<= {}", m);
+        logger.debug("<= {}", m);
         if (null == m) {
             return;
         }


### PR DESCRIPTION
Logging of written messages is done with loglevel 'info'. This causes a lot of noise in an applications log output. Use 'debug' log level for the written messages, which is in line with the log level used to log messages read from dbus (see MessageReader.readMessage())