### PR TITLE
feat: reads machine-id from /etc/machine-id

### DIFF
--- a/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
+++ b/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
@@ -264,6 +264,9 @@ public final class DBusConnection extends AbstractConnection {
             uuidfile = new File("/usr/local/var/lib/dbus/machine-id");
         }
         if (!uuidfile.exists()) {
+            uuidfile = new File("/etc/machine-id");
+        }
+        if (!uuidfile.exists()) {
             throw new DBusException("Cannot Resolve Session Bus Address");
         }
 


### PR DESCRIPTION
It seems like on the default installation of some OS (NixOS, CentOS...), the machine-id can only be found in /etc/machine-id instead of /var/lib/dbus/machine-id. Knowing that the content of both files must match in the event that they both exist (usually via a symlink), the library might as well check for both locations.

See https://www.freedesktop.org/software/systemd/man/machine-id.html