### PR TITLE
Feature/fix imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,14 +121,12 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>1.2.3</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- Mockito mocking framework. -->

--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,14 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>1.2.3</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Mockito mocking framework. -->

--- a/src/main/java/org/freedesktop/dbus/bin/CreateInterface.java
+++ b/src/main/java/org/freedesktop/dbus/bin/CreateInterface.java
@@ -349,7 +349,8 @@ public class CreateInterface {
         def.packageName     = def.interfaceName.replaceAll("\\.[^.]*$", "");
 
         String parentPack = def.interfaceName.replaceAll("\\.[^.]*$", "");
-        def.className = "I" + def.interfaceName.replaceAll("^.*\\.([^.]*)$", "$1");
+        String interfaceName = def.interfaceName.replaceAll("^.*\\.([^.]*)$", "$1");
+        def.className = "I" + interfaceName.substring(0, 1).toUpperCase() + interfaceName.substring(1);
 
         def.file = parentPack.replaceAll("\\.", "/") + "/" + def.className + ".java";
         def.path = def.file.replaceAll("/[^/]*$", "");
@@ -550,6 +551,7 @@ public class CreateInterface {
                 def.imports.add(sspack + ".*");
             }
 
+            logger.info ( "  - writing interface {}.{}", def.packageName, def.className);
             factory.init(def.file, def.path);
             def.write (factory.createPrintStream(def.file));
         }
@@ -650,7 +652,7 @@ public class CreateInterface {
 
         @Override
         public PrintStream createPrintStream(String file) throws IOException {
-            logger.info("Writing to {}", file);
+            logger.debug("Writing to {}", file);
             System.out.println("/* File: " + file + " */");
             return System.out;
         }
@@ -675,7 +677,7 @@ public class CreateInterface {
          */
         @Override
         public PrintStream createPrintStream(final String file) throws IOException {
-            logger.info("Writing to {}", file);
+            logger.debug("Writing to {}", file);
             return new PrintStream(new FileOutputStream(file));
         }
 


### PR DESCRIPTION
Fixed imports by 1) don't write interface class file during parseInterface, but save all the info to a definitions array. 2) Track the structs created in each package in class variable structPackages. 3) After xml has been parsed, write out all the interface classes from the definitions, using the packages saved in 2) to create the import statements.

All the firewalld objects provided earlier now compile cleanly.  The code is not that elegant, but since you are re-visting this area anyway...