### PR TITLE
Fixed sending lists over the bus in an async manner

### DIFF
--- a/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
+++ b/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
@@ -510,10 +510,7 @@ public abstract class AbstractConnection implements Closeable {
     public <A> void callWithCallback(DBusInterface object, String m, CallbackHandler<A> callback,
             Object... parameters) {
         logger.trace("callWithCallback({}, {}, {})", object, m, callback);
-        Class<?>[] types = new Class[parameters.length];
-        for (int i = 0; i < parameters.length; i++) {
-            types[i] = parameters[i].getClass();
-        }
+        Class<?>[] types = createTypesArray( parameters );
         RemoteObject ro = getImportedObjects().get(object);
 
         try {
@@ -546,10 +543,7 @@ public abstract class AbstractConnection implements Closeable {
      * @return A handle to the call.
      */
     public DBusAsyncReply<?> callMethodAsync(DBusInterface object, String m, Object... parameters) {
-        Class<?>[] types = new Class[parameters.length];
-        for (int i = 0; i < parameters.length; i++) {
-            types[i] = parameters[i].getClass();
-        }
+        Class<?>[] types = createTypesArray( parameters );
         RemoteObject ro = getImportedObjects().get(object);
 
         try {
@@ -568,6 +562,20 @@ public abstract class AbstractConnection implements Closeable {
             logger.debug("", e);
             throw new DBusExecutionException(e.getMessage());
         }
+    }
+    
+    private Class<?>[] createTypesArray( Object... parameters ){
+        Class<?>[] types = new Class[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            types[i] = parameters[i].getClass();
+            if( parameters[i] instanceof java.util.List<?> ){
+                try{
+                    types[i] = Class.forName( "java.util.List" );
+                }catch( ClassNotFoundException ex ){}
+            }
+        }
+    
+        return types;
     }
 
     protected void handleException(AbstractConnection dbusConnection, Message methodOrSignal,

--- a/src/test/java/org/freedesktop/dbus/test/helper/SampleClass.java
+++ b/src/test/java/org/freedesktop/dbus/test/helper/SampleClass.java
@@ -339,4 +339,9 @@ public class SampleClass implements SampleRemoteInterface, SampleRemoteInterface
     public Map<DBusPath, DBusPath> pathmaprv(Map<DBusPath, DBusPath> map) {
         return map;
     }
+    
+    @Override
+    public SampleStruct returnSamplestruct( SampleStruct s ){
+        return s;
+    }
 }

--- a/src/test/java/org/freedesktop/dbus/test/helper/interfaces/SampleRemoteInterface2.java
+++ b/src/test/java/org/freedesktop/dbus/test/helper/interfaces/SampleRemoteInterface2.java
@@ -68,4 +68,7 @@ public interface SampleRemoteInterface2 extends DBusInterface {
     @IntrospectionDescription("Test Introspect on a different interface")
     String Introspect();
     //CHECKSTYLE:ON
+    
+    @IntrospectionDescription("Returns the given struct")
+    SampleStruct returnSamplestruct( SampleStruct struct );
 }


### PR DESCRIPTION
When sending lists over the bus using callMethodAsync, if one of the parameters is a list(e.g. subclass of `java.util.list`), but not a `java.util.list` directly, it will fail to send over the bus due to the library trying to interpret the `ArrayList` as a param to the function.

Also added a test to ensure that this behavior does work correctly.

I'm not exactly sure why this is not needed for `Struct`s.  It may also be needed for subclasses of `java.util.Map`, but that is not a use-case for me.