### PR TITLE
Send/Recieve arbitrary signals

### DIFF
--- a/src/main/java/org/freedesktop/dbus/DBusMatchRule.java
+++ b/src/main/java/org/freedesktop/dbus/DBusMatchRule.java
@@ -45,6 +45,13 @@ public class DBusMatchRule {
         this.member = _member;
     }
 
+    public DBusMatchRule(String _type, String _iface, String _member, String _object) {
+        this.type = _type;
+        this.iface = _iface;
+        this.member = _member;
+        this.object = _object;
+    }
+
     public DBusMatchRule(DBusExecutionException e) throws DBusException {
         this(e.getClass());
         member = null;

--- a/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
+++ b/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
@@ -293,6 +293,35 @@ public class DirectConnection extends AbstractConnection {
     }
 
     @Override
+    protected void removeGenericSigHandler(DBusMatchRule rule, DBusSigHandler<DBusSignal> handler) throws DBusException {
+        SignalTuple key = new SignalTuple(rule.getInterface(), rule.getMember(), rule.getObject(), rule.getSource());
+        synchronized (getGenericHandledSignals()) {
+            List<DBusSigHandler<DBusSignal>> v = getGenericHandledSignals().get(key);
+            if (null != v) {
+                v.remove(handler);
+                if (0 == v.size()) {
+                    getGenericHandledSignals().remove(key);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void addGenericSigHandler(DBusMatchRule rule, DBusSigHandler<DBusSignal> handler) throws DBusException {
+        SignalTuple key = new SignalTuple(rule.getInterface(), rule.getMember(), rule.getObject(), rule.getSource());
+        synchronized (getGenericHandledSignals()) {
+            List<DBusSigHandler<DBusSignal>> v = getGenericHandledSignals().get(key);
+            if (null == v) {
+                v = new ArrayList<>();
+                v.add(handler);
+                getGenericHandledSignals().put(key, v);
+            } else {
+                v.add(handler);
+            }
+        }
+    }
+
+    @Override
     public DBusInterface getExportedObject(String source, String path) throws DBusException {
         return getExportedObject(path);
     }

--- a/src/test/java/org/freedesktop/dbus/test/helper/signals/handler/GenericHandlerWithDecode.java
+++ b/src/test/java/org/freedesktop/dbus/test/helper/signals/handler/GenericHandlerWithDecode.java
@@ -1,0 +1,51 @@
+package org.freedesktop.dbus.test.helper.signals.handler;
+
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+public class GenericHandlerWithDecode implements DBusSigHandler<DBusSignal> {
+
+    private final UInt32 expectedIntResult;
+    private final String expectedStringResult;
+
+    private Object[] parameters;
+
+    public GenericHandlerWithDecode( UInt32 _expectedIntResult, String _expectedStringResult ){
+        expectedIntResult = _expectedIntResult;
+        expectedStringResult = _expectedStringResult;
+    }
+
+    @Override
+    public void handle(DBusSignal s) {
+        try{
+            parameters = s.getParameters();
+        }catch( DBusException ex ){
+            fail( "Unexpected DBusException", ex );
+        }
+    }
+
+    public UInt32 getExpectedIntResult() {
+        return expectedIntResult;
+    }
+
+    public String getExpectedStringResult() {
+        return expectedStringResult;
+    }
+
+    public void incomingSameAsExpected(){
+        assertEquals( parameters.length, 2 );
+
+        if (expectedIntResult != null) {
+            assertEquals((UInt32)parameters[0], getExpectedIntResult(), "Retrieved int does not match.");
+        }
+        if (expectedStringResult != null) {
+            assertEquals((String)parameters[1], getExpectedStringResult(), "Retrieved string does not match.");
+        }
+    }
+
+}

--- a/src/test/java/org/freedesktop/dbus/test/helper/signals/handler/GenericSignalHandler.java
+++ b/src/test/java/org/freedesktop/dbus/test/helper/signals/handler/GenericSignalHandler.java
@@ -1,0 +1,23 @@
+package org.freedesktop.dbus.test.helper.signals.handler;
+
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.messages.DBusSignal;
+
+public class GenericSignalHandler implements DBusSigHandler<DBusSignal> {
+
+    private int testRuns;
+
+    public GenericSignalHandler(){
+        testRuns = 0;
+    }
+
+    @Override
+    public void handle(DBusSignal s) {
+        testRuns++;
+        System.out.println( "GenericSignalHandler called" );
+    }
+
+    public int getActualTestRuns(){
+        return testRuns;
+    }
+}


### PR DESCRIPTION
This adds the ability to both send and recieve arbitrary signals on the bus.
To recieve an arbitrary signal, you must implement DBusSigHandler(as normal),
but the generic type is just DBusSignal.  This adds two new methods to help
accomplish this on AbstractConnection: addGenericHandler and
removeGenericHandler.  The new methods are required in order for the code
that will normally create a new subclass of DBusSignal, which for arbitrary
signals we can't have.
