### PR TITLE
Support for empty collections + some fixes

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/connections/transports/TcpTransport.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/connections/transports/TcpTransport.java
@@ -38,7 +38,9 @@ public class TcpTransport extends AbstractTransport {
             socket = new Socket();
             socket.connect(new InetSocketAddress(getAddress().getHost(), getAddress().getPort()));
         }
-
+        
+        setInputReader(socket.getInputStream());
+        setOutputWriter(socket.getOutputStream());
         getLogger().trace("Setting timeout to {} on Socket", getTimeout());
         socket.setSoTimeout(getTimeout());
 

--- a/dbus-java/src/main/java/org/freedesktop/dbus/messages/EmptyCollectionHelper.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/messages/EmptyCollectionHelper.java
@@ -1,0 +1,133 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.messages;
+
+import java.util.Arrays;
+
+final class EmptyCollectionHelper {
+
+	/**
+	 * This function determine the new offset in signature for empty Dictionary/Map collections.
+	 *  Normally the element inside a collection determines the new offset, 
+	 *  however in case of empty collections there is no element to determine the sub signature of the list
+	 *  so this function determines which part of the signature to skip
+	 * @param sigb the total signature
+	 * @param currentOffset the current offset within the signature
+	 * @return the index of the last element of the collection (subtype)
+	 */
+	static int determineSignatureOffsetDict(byte[] sigb, int currentOffset) {
+		return determineEndOfBracketStructure(sigb, currentOffset, '{' , '}');
+	}
+	
+	/**
+	 * This function determine the new offset in signature for empty Array/List collections.
+	 *  Normally the element inside a collection determines the new offset, 
+	 *  however in case of empty collections there is no element to determine the sub signature of the list
+	 *  so this function determines which part of the signature to skip
+	 * @param sigb the total signature
+	 * @param currentOffset the current offset within the signature
+	 * @return the index of the last element of the collection (subtype)
+	 */
+	static int determineSignatureOffsetArray(byte[] sigb, int currentOffset) {
+		String sigSubString = determineSubSignature(sigb, currentOffset);
+		
+		// End of string so can't have any more offset
+		if (sigSubString.isEmpty()) {
+			return currentOffset;
+		}
+		
+		ECollectionSubType newtype = determineCollectionSubType((char)sigb[currentOffset]);
+		switch (newtype) {
+			case ARRAY:
+				// array in array so look at the next type
+				return determineSignatureOffsetArray(sigb, currentOffset + 1);
+			case DICT:
+				return determineSignatureOffsetDict(sigb, currentOffset);
+			case STRUCT:
+				return determineSignatureOffsetStruct(sigb, currentOffset);
+			case PRIMITIVE:
+				//primitive is always one element so no need to skip more
+				return currentOffset;
+			default:
+				break;
+	
+		}
+		throw new IllegalStateException("Unable to parse signature for empty collection");
+	}
+
+	private static int determineSignatureOffsetStruct(byte[] sigb, int currentOffset) {
+		return determineEndOfBracketStructure(sigb, currentOffset, '(' , ')');
+	}
+
+	/**
+	 * This is a generic function to determine the end of a structure that has opening and closing characters.
+	 * Currently used for Struct () and Dict {}
+     * 
+	 */
+	private static int determineEndOfBracketStructure(byte[] sigb, int currentOffset, char openChar, char closeChar) {
+		String sigSubString = determineSubSignature(sigb, currentOffset);
+		
+		// End of string so can't have any more offset
+		if (sigSubString.isEmpty()) {
+			return currentOffset;
+		}
+		int i = 0;
+		int depth = 0;
+		
+		for(char chr : sigSubString.toCharArray()) {
+			//book keeping of depth of nested structures to solve opening closing bracket problem
+			if (chr == openChar) {
+				depth ++;
+			} else if (chr == closeChar) {
+				depth --;					
+			}
+			if (depth == 0) {
+				return currentOffset + i;
+			}
+			i++;
+		}
+		throw new IllegalStateException("Unable to parse signature for empty collection");
+	}
+	
+	private static String determineSubSignature(byte[] sigb, int currentOffset) {
+		byte[] restSigbytes = Arrays.copyOfRange(sigb, currentOffset, sigb.length);
+		return new String(restSigbytes);
+	}
+
+	/**
+	 * The starting type determines of a collection determines when it ends
+	 * @param sig the signature letter of the type
+	 */
+	private static ECollectionSubType determineCollectionSubType(char sig) {
+		switch (sig) {
+			case '(':
+				return ECollectionSubType.STRUCT;
+			case '{':
+				return ECollectionSubType.DICT;
+			case 'a':
+				return ECollectionSubType.ARRAY;
+			default:
+				// of course there can be other types but those shouldn't be allowed in this part of the signature
+				return ECollectionSubType.PRIMITIVE;
+		}
+	}
+
+	/**
+	 * Internal Enumeration used to group the types of element
+	 */
+	enum ECollectionSubType {
+		STRUCT,
+		DICT,
+		ARRAY,
+		PRIMITIVE
+	}	
+}

--- a/dbus-java/src/main/java/org/freedesktop/dbus/messages/Message.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/messages/Message.java
@@ -661,21 +661,19 @@ public class Message {
                     for (Object o : contents) {
                         diff = appendone(sigb, i, o);
                     }
+                    if (contents.length == 0) {
+                        diff = EmptyCollectionHelper.determineSignatureOffsetArray(sigb, diff);
+                    }
                     i = diff;
                 } else if (data instanceof Map) {
                     int diff = i;
-                    ensureBuffers(((Map<?, ?>) data).size() * 6);
-                    for (Map.Entry<Object, Object> o : ((Map<Object, Object>) data).entrySet()) {
+                    Map<Object, Object> map = (Map<Object, Object>) data;
+                    ensureBuffers(map.size() * 6);
+					for (Map.Entry<Object, Object> o : map.entrySet()) {
                         diff = appendone(sigb, i, o);
                     }
-                    if (i == diff) {
-                        // advance the type parser even on 0-size arrays.
-                        List<Type> temp = new ArrayList<>();
-                        byte[] temp2 = new byte[sigb.length - diff];
-                        System.arraycopy(sigb, diff, temp2, 0, temp2.length);
-                        String temp3 = new String(temp2);
-                        int temp4 = Marshalling.getJavaType(temp3, temp, 1);
-                        diff += temp4;
+                    if (map.size() == 0) {
+                        diff = EmptyCollectionHelper.determineSignatureOffsetDict(sigb, diff);
                     }
                     i = diff;
                 } else {
@@ -684,6 +682,9 @@ public class Message {
                     int diff = i;
                     for (Object o : contents) {
                         diff = appendone(sigb, i, o);
+                    }
+                    if (contents.length == 0) {
+                        diff = EmptyCollectionHelper.determineSignatureOffsetArray(sigb, diff);
                     }
                     i = diff;
                 }

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/TestAll.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/TestAll.java
@@ -68,16 +68,18 @@ import org.freedesktop.dbus.test.helper.signals.handler.ObjectSignalHandler;
 import org.freedesktop.dbus.test.helper.signals.handler.PathSignalHandler;
 import org.freedesktop.dbus.test.helper.signals.handler.RenamedSignalHandler;
 import org.freedesktop.dbus.test.helper.signals.handler.SignalHandler;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
 import org.freedesktop.dbus.test.helper.structs.SampleStruct;
 import org.freedesktop.dbus.test.helper.structs.SampleStruct2;
 import org.freedesktop.dbus.test.helper.structs.SampleStruct3;
+import org.freedesktop.dbus.test.helper.structs.SampleStruct4;
 import org.freedesktop.dbus.test.helper.structs.SampleTuple;
 import org.freedesktop.dbus.types.UInt16;
 import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.UInt64;
 import org.freedesktop.dbus.types.Variant;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.github.hypfvieh.util.TimeMeasure;
@@ -91,13 +93,13 @@ public class TestAll {
     public static final String TEST_OBJECT_PATH = "/TestAll";
 
     // CHECKSTYLE:OFF
-    private static DBusConnection serverconn = null;
-    private static DBusConnection clientconn = null;
-    private static SampleClass tclass;
+    private DBusConnection serverconn = null;
+    private DBusConnection clientconn = null;
+    private SampleClass tclass;
     // CHECKSTYLE:ON
 
-    @BeforeAll
-    public static void beforeClass() throws DBusException {
+    @BeforeEach
+    public void setUp() throws DBusException {
         serverconn = DBusConnection.getConnection(DBusBusType.SESSION);
         clientconn = DBusConnection.getConnection(DBusBusType.SESSION);
         serverconn.setWeakReferences(true);
@@ -111,8 +113,8 @@ public class TestAll {
         serverconn.addFallback("/FallbackTest", tclass);
     }
 
-    @AfterAll
-    public static void afterClass() {
+    @AfterEach
+    public void tearDown() {
         System.out.println("Checking for outstanding errors");
         DBusExecutionException dbee = serverconn.getError();
         if (null != dbee) {
@@ -379,6 +381,24 @@ public class TestAll {
         }
     }
 
+    @Test
+    public void testListOfStruct() throws DBusException {
+        SampleRemoteInterface tri = (SampleRemoteInterface) clientconn.getPeerRemoteObject("foo.bar.Test", TEST_OBJECT_PATH);
+
+        IntStruct elem1 = new IntStruct(3, 7);
+        IntStruct elem2 = new IntStruct(9, 14);
+        List<IntStruct> list = Arrays.asList(elem1, elem2);
+        SampleStruct4 param = new SampleStruct4(list);
+        int[][] out = tri.testListstruct(param);
+        if (out.length != 2) {
+            fail("teststructstruct returned the wrong thing: " + Arrays.deepToString(out));
+        }
+        assertEquals(elem1.getValue1(), out[0][0]);
+        assertEquals(elem1.getValue2(), out[0][1]);
+        assertEquals(elem2.getValue1(), out[1][0]);
+        assertEquals(elem2.getValue2(), out[1][1]);
+    }
+    
     public void testFrob() throws DBusException {
         SampleRemoteInterface tri = (SampleRemoteInterface) clientconn.getPeerRemoteObject("foo.bar.Test", TEST_OBJECT_PATH);
         System.out.println("frobnicating");

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/ISampleCollectionInterface.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/ISampleCollectionInterface.java
@@ -1,0 +1,54 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty;
+
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.test.collections.empty.structs.ArrayStructIntStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.ArrayStructPrimitive;
+import org.freedesktop.dbus.test.collections.empty.structs.DeepArrayStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.DeepListStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.DeepMapStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.ListMapStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.ListStructPrimitive;
+import org.freedesktop.dbus.test.collections.empty.structs.ListStructStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.MapArrayStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.MapStructIntStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.MapStructPrimitive;
+
+/**
+ * A sample remote interface which implements same function for all of the structs
+ */
+public interface ISampleCollectionInterface extends DBusInterface {
+
+	String testListPrimitive(ListStructPrimitive param);
+	
+	String testListIntStruct(ListStructStruct param);
+	
+	String testDeepList(DeepListStruct param);
+	
+	String testArrayPrimitive(ArrayStructPrimitive param);
+
+	String testArrayIntStruct(ArrayStructIntStruct param);
+	
+	String testDeepArray(DeepArrayStruct param);
+	
+	String testMapPrimitive(MapStructPrimitive param);
+	
+	String testMapIntStruct(MapStructIntStruct param);
+	
+	String testDeepMap(DeepMapStruct param);
+	
+	String testMixedListMap(ListMapStruct param);
+
+	String testMixedMapArray(MapArrayStruct param);
+
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/SampleCollectionImpl.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/SampleCollectionImpl.java
@@ -1,0 +1,101 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+package org.freedesktop.dbus.test.collections.empty;
+
+import org.freedesktop.dbus.test.collections.empty.structs.ArrayStructIntStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.ArrayStructPrimitive;
+import org.freedesktop.dbus.test.collections.empty.structs.DeepArrayStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.DeepListStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.DeepMapStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.IEmptyCollectionStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.ListMapStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.ListStructPrimitive;
+import org.freedesktop.dbus.test.collections.empty.structs.ListStructStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.MapArrayStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.MapStructIntStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.MapStructPrimitive;
+
+public class SampleCollectionImpl implements ISampleCollectionInterface {
+
+	@Override
+	public String testListPrimitive(ListStructPrimitive param) {
+		return testValue(param);
+	}
+
+	@Override
+	public String testListIntStruct(ListStructStruct param) {
+		return testValue(param);
+	}
+
+	@Override
+	public String testDeepList(DeepListStruct param) {
+		return testValue(param);	
+	}
+
+	@Override
+	public String testArrayPrimitive(ArrayStructPrimitive param) {
+		return testValue(param);
+
+	}
+
+	@Override
+	public String testArrayIntStruct(ArrayStructIntStruct param) {
+		return testValue(param);
+	}
+
+	@Override
+	public String testDeepArray(DeepArrayStruct param) {
+		return testValue(param);
+	}
+
+	@Override
+	public String testMapPrimitive(MapStructPrimitive param) {
+		return testValue(param);
+	}
+
+	@Override
+	public String testMapIntStruct(MapStructIntStruct param) {
+		return testValue(param);
+	}
+
+	@Override
+	public String testDeepMap(DeepMapStruct param) {
+		return testValue(param);
+	}
+
+	@Override
+	public String testMixedListMap(ListMapStruct param) {
+		return testValue(param);
+	}
+
+	@Override
+	public String testMixedMapArray(MapArrayStruct param) {
+		return testValue(param);
+	}
+
+	@Override
+	public boolean isRemote() {
+		return false;
+	}
+
+	@Override
+	public String getObjectPath() {
+		return "/org/dbus/test/EmptyCollections";
+	}
+
+	private String testValue(IEmptyCollectionStruct<?> param) {
+		if (param.getValue() == null) {
+			throw new IllegalArgumentException("Incorrect param value");
+		}
+		return param.isEmpty() ? param.getValidationValue() : param.getStringTestValue();		
+	}
+	
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/TestEmptyCollections.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/TestEmptyCollections.java
@@ -1,0 +1,243 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+package org.freedesktop.dbus.test.collections.empty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnection.DBusBusType;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
+import org.freedesktop.dbus.test.collections.empty.structs.ArrayStructIntStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.ArrayStructPrimitive;
+import org.freedesktop.dbus.test.collections.empty.structs.DeepArrayStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.DeepListStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.DeepMapStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.IEmptyCollectionStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.ListMapStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.ListStructPrimitive;
+import org.freedesktop.dbus.test.collections.empty.structs.ListStructStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.MapArrayStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.MapStructIntStruct;
+import org.freedesktop.dbus.test.collections.empty.structs.MapStructPrimitive;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * 
+ * The test structure is a bit of a complex constructions. However the goal is very simple
+ * 
+ * The class tests all structs implementing IEmptyCollectionStruct
+ * 
+ * There are two tests:
+ * 
+ * Empty test:
+ * 
+ * The test creates an empty object with emptyFactory function and the testString and sends the object to the {@link ISampleCollectionInterface}. 
+ * This interface returns the {@link IEmptyCollectionStruct#getValidationValue()} that value can be 
+ * used to determine whether (de)serialization of object with an empty collection is executed correctly.
+ *
+ * Non Empty test:
+ * 
+ * The test creates an non empty object with nonEmptyFactory function and the testString and sends the object to the {@link ISampleCollectionInterface}. 
+ * This interface returns the {@link IEmptyCollectionStruct#getStringTestValue()} that value can be 
+ * used to determine whether (de)serialization of non empty collection is executed correctly.
+ *
+ */
+class TestEmptyCollections {
+
+	private DBusConnection serverconn;
+	private DBusConnection clientconn;
+	private ISampleCollectionInterface clientObj;
+
+	@BeforeEach
+	public void setUp() throws DBusException {
+		serverconn = DBusConnection.getConnection(DBusBusType.SESSION);
+		clientconn = DBusConnection.getConnection(DBusBusType.SESSION);
+		serverconn.setWeakReferences(true);
+		clientconn.setWeakReferences(true);
+
+		/** This exports an instance of the test class as the object /Test. */
+		ISampleCollectionInterface serverImpl = new SampleCollectionImpl();
+		serverconn.exportObject(serverImpl.getObjectPath(), serverImpl);
+
+		clientObj = clientconn.getRemoteObject(serverconn.getUniqueName(), serverImpl.getObjectPath(),
+				ISampleCollectionInterface.class);
+
+	}
+
+	@AfterEach
+	public void tearDown() {
+		DBusExecutionException dbee = serverconn.getError();
+		if (null != dbee) {
+			throw dbee;
+		}
+		dbee = clientconn.getError();
+		if (null != dbee) {
+			throw dbee;
+		}
+		clientconn.disconnect();
+		serverconn.disconnect();
+	}
+
+	/**
+	 * Parameterized test that collection will still know the next value. The Server
+	 * will throw error or return wrong string if the test fails
+	 * 
+	 * @param arguments this contains the information required to build and call a
+	 *                  function
+	 * @param name      the name is used for validation and naming purpose should
+	 *                  described the structure
+	 */
+	@DisplayName("testCollectionsEmpty")
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("scenarios")
+	<T extends IEmptyCollectionStruct<?>> void testEmpty(ArgumentObj<T> arguments, String name) {
+		T object = arguments.factoryEmpty.apply(name);
+		String result = arguments.function.apply(clientObj, object);
+		assertEquals(object.getValidationValue(), result);
+	}
+
+	/**
+	 * Parameterized test that collection will still know the next value. The Server
+	 * will throw error or return wrong string if the test fails
+	 * 
+	 * @param arguments this contains the information required to build and call a
+	 *                  function
+	 * @param name      the name is used for validation and naming purpose should
+	 *                  described the structure
+	 */
+	@DisplayName("testCollectionsNotEmpty")
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("scenarios")
+	<T extends IEmptyCollectionStruct<?>> void testNonEmpty(ArgumentObj<T> arguments, String name, String validationValue) {
+		T object = arguments.factoryNonEmpty.apply(name);
+		String result = arguments.function.apply(clientObj, object);
+		assertEquals(validationValue, result);
+	}
+	
+	/**
+	 * List of arguments for each scenario:
+	 * 1: Interface function to use for to test this struct
+	 * 2: Factory to create an empty structure
+	 * 3: Factory to create an non empty structure
+	 * 4: Name, which is also used for validating empty collections
+	 * 5: Expected to string value for non empty collection test
+	 */
+	static Stream<Arguments> scenarios() {
+		return Stream.of(
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testListPrimitive,
+						s -> new ListStructPrimitive(Collections.emptyList(), s),
+						s -> new ListStructPrimitive(Arrays.asList(1, 2), s)), "ListPrimative", "1,2"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testListIntStruct,
+						s -> new ListStructStruct(Collections.emptyList(), s),
+						s -> new ListStructStruct(Arrays.asList(new IntStruct(5, 6)), s)), "ListStruct", "(5,6)"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testArrayPrimitive,
+						s -> new ArrayStructPrimitive(new int[0], s),
+						s -> new ArrayStructPrimitive(new int[] {4,5}, s)), "ArrayPrimative", "4,5"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testArrayIntStruct,
+						s -> new ArrayStructIntStruct(new IntStruct[0], s),
+						s -> new ArrayStructIntStruct(new IntStruct[] { new IntStruct(9, 12)}, s)),
+						"ArrayIntStruct", "(9,12)"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testMapPrimitive,
+						s -> new MapStructPrimitive(Collections.emptyMap(), s),
+						s -> new MapStructPrimitive(getIntHashMap(), s)), "MapPrimative", "{test:8}"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testMapIntStruct,
+						s -> new MapStructIntStruct(Collections.emptyMap(), s),
+						s -> new MapStructIntStruct(getIntStructHashMap(), s)), "MapIntStruct", "{other:(12,17)}"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testDeepList,
+						s -> new DeepListStruct(Collections.emptyList(), s),
+						s -> new DeepListStruct(getDeepList(), s)), "DeepListStruct", "[[[(111,44)]]]"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testDeepArray,
+						s -> new DeepArrayStruct(new IntStruct[0][][], s),
+						s -> new DeepArrayStruct(getDeepArrayStruct(), s)), "DeepArrayStruct", "[[[(131,145)]]]"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testDeepMap,
+						s -> new DeepMapStruct(Collections.emptyMap(), s),
+						s -> new DeepMapStruct(getDeepMapStruct(), s)), "DeepMapStruct",
+						"{complete:{inbetween:{test:(42,19)}}}"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testMixedListMap,
+						s -> new ListMapStruct(Collections.emptyList(), s),
+						s -> new ListMapStruct(Arrays.asList(getIntStructHashMap()), s)), "mixedListMapStruct",
+						"[{other=(12,17)}]"),
+				Arguments.of(new ArgumentObj<>(ISampleCollectionInterface::testMixedMapArray,
+						s -> new MapArrayStruct(Collections.emptyMap(), s),
+						s -> new MapArrayStruct(getMapArray(), s)), "mixedMapArrayStruct", "{other=[(99,33)]}")
+				);
+	}
+
+	private static Map<String, IntStruct[]> getMapArray() {
+		Map<String, IntStruct[]> map = new HashMap<>();
+		map.put("other", new IntStruct[] {new IntStruct(99, 33)});
+		return map;
+	}
+
+	private static Map<String, Map<String, Map<String, IntStruct>>> getDeepMapStruct() {
+		Map<String, Map<String, Map<String, IntStruct>>> outerMap = new HashMap<>();
+		Map<String, Map<String, IntStruct>> midlleMap = new HashMap<>();
+		Map<String, IntStruct> innerMap = new HashMap<>();
+		innerMap.put("test", new IntStruct(42, 19));
+		midlleMap.put("inbetween", innerMap);
+		outerMap.put("complete", midlleMap);
+		return outerMap;
+	}
+
+	private static IntStruct[][][] getDeepArrayStruct() {
+		IntStruct[][][] array = new IntStruct[1][1][1];
+		array[0][0][0] = new IntStruct(131, 145);
+		return array;
+	}
+
+	private static List<List<List<IntStruct>>> getDeepList() {
+		return Arrays.asList(Arrays.asList(Arrays.asList(new IntStruct(111, 44))));
+	}
+	
+	private static Map<String, IntStruct> getIntStructHashMap() {
+		Map<String, IntStruct> map = new HashMap<>();
+		map.put("other", new IntStruct(12, 17));
+		return map;
+	}
+
+	private static Map<String, Integer> getIntHashMap() {
+		Map<String, Integer> map = new HashMap<>();
+		map.put("test", 8);
+		return map;
+	}
+
+	/**
+	 * Wrapper object for first three arguments
+	 */
+	private final static class ArgumentObj<T> {
+		private final BiFunction<ISampleCollectionInterface, T, String> function;
+		private final Function<String, T> factoryEmpty;
+		private Function<String, T> factoryNonEmpty;
+
+		public ArgumentObj(BiFunction<ISampleCollectionInterface, T, String> function, Function<String, T> factoryEmpty,
+				Function<String, T> factoryNonEmpty) {
+			this.function = function;
+			this.factoryEmpty = factoryEmpty;
+			this.factoryNonEmpty = factoryNonEmpty;
+		}
+	}
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ArrayStructIntStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ArrayStructIntStruct.java
@@ -1,0 +1,56 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
+
+public final class ArrayStructIntStruct extends Struct implements IEmptyCollectionStruct<IntStruct[]> {
+
+	@Position(0)
+	private final IntStruct[] list;
+
+	@Position(1)
+	private final String validationValue;
+
+	public ArrayStructIntStruct(IntStruct[] list, String validationValue) {
+		this.list = list.clone();
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public IntStruct[] getValue() {
+		return list.clone();
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		return Stream.of(list)
+				.map(i -> i.toSimpleString())
+				.collect(Collectors.joining(","));
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return list.length == 0;
+	}
+
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ArrayStructPrimitive.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ArrayStructPrimitive.java
@@ -1,0 +1,53 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+public final class ArrayStructPrimitive extends Struct implements IEmptyCollectionStruct<int[]> {
+
+	@Position(0)
+	private final int[] list;
+
+	@Position(1)
+	private final String validationValue;
+
+	public ArrayStructPrimitive(int[] list, String validationValue) {
+		this.list = list.clone();
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public int[] getValue() {
+		return list.clone();
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		return IntStream.of(list).mapToObj(i -> Integer.toString(i)).collect(Collectors.joining(","));
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return list.length == 0;
+	}
+
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/DeepArrayStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/DeepArrayStruct.java
@@ -1,0 +1,65 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
+
+public final class DeepArrayStruct extends Struct implements IEmptyCollectionStruct<IntStruct[][][]> {
+
+	@Position(0)
+	private final IntStruct[][][] list;
+
+	@Position(1)
+	private final String validationValue;
+
+	public DeepArrayStruct(IntStruct[][][] list, String validationValue) {
+		this.list = list.clone();
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public IntStruct[][][] getValue() {
+		return list.clone();
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		String string = "["; 
+			for (IntStruct[][] l1 : list) {
+				string += "[";
+				for (IntStruct[] l2 : l1) {
+					string += "[";
+					for (IntStruct e : l2) {
+						string += e.toSimpleString();
+					}
+					string += "]";
+				}
+				string += "]";
+			}
+			string += "]";
+				
+		return string;
+				
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return list.length == 0;
+	}
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/DeepListStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/DeepListStruct.java
@@ -1,0 +1,67 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.List;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
+
+public final class DeepListStruct extends Struct implements IEmptyCollectionStruct<List<List<List<IntStruct>>>> {
+
+	@Position(0)
+	private final List<List<List<IntStruct>>> list;
+
+	@Position(1)
+	private final String validationValue;
+
+	public DeepListStruct(List<List<List<IntStruct>>> list, String validationValue) {
+		this.list = list;
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public List<List<List<IntStruct>>> getValue() {
+		return list;
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		String string = "["; 
+			for (List<List<IntStruct>> l1 : list) {
+				string += "[";
+				for (List<IntStruct> l2 : l1) {
+					string += "[";
+					for (IntStruct e : l2) {
+						string += e.toSimpleString();
+					}
+					string += "]";
+				}
+				string += "]";
+			}
+			string += "]";
+				
+		return string;
+				
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return list.isEmpty();
+	}
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/DeepMapStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/DeepMapStruct.java
@@ -1,0 +1,70 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
+
+public final class DeepMapStruct extends Struct implements IEmptyCollectionStruct<Map<String,Map<String,Map<String,IntStruct>>>> {
+
+	@Position(0)
+	private final Map<String,Map<String,Map<String,IntStruct>>> map;
+
+	@Position(1)
+	private final String validationValue;
+
+	public DeepMapStruct(Map<String,Map<String,Map<String,IntStruct>>> map, String validationValue) {
+		this.map = map;
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public Map<String,Map<String,Map<String,IntStruct>>> getValue() {
+		return map;
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		String string = "{"; 
+			for (Entry<String, Map<String, Map<String, IntStruct>>> es1 : map.entrySet()) {
+				string += String.format( "%s:", es1.getKey());
+				string += "{";
+				for (Entry<String, Map<String, IntStruct>> es2 : es1.getValue().entrySet()) {
+					string += String.format( "%s:", es2.getKey());
+					string += "{";
+					for (Entry<String, IntStruct> e : es2.getValue().entrySet()) {
+						string += String.format("%s:%s,", e.getKey(), e.getValue().toSimpleString());
+					}
+					string += "},";
+				}
+				string += "},";
+			}
+			string += "}";
+				
+		return string.replaceAll(",}","}");
+				
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
+	}
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/IEmptyCollectionStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/IEmptyCollectionStruct.java
@@ -1,0 +1,27 @@
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+/**
+ * Interface is used to make the TestEmptyCollection usable for parameterized testing  
+ */
+public interface IEmptyCollectionStruct<T> {
+
+	/**
+	 * Return the collection structure
+	 */
+	T getValue();
+	
+	/**
+	 * The validation String value, which is used to determine if next value is also still intact with empty collection
+	 */
+	String getValidationValue();
+	
+	/**
+	 * A to string value of the collection to determine a correct value
+	 */
+	String getStringTestValue();
+
+	/**
+	 * Return true when collection part of the structure is empty
+	 */
+	boolean isEmpty();
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListMapStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListMapStruct.java
@@ -1,0 +1,62 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
+
+public final class ListMapStruct extends Struct implements IEmptyCollectionStruct<List<Map<String,IntStruct>>> {
+
+	@Position(0)
+	private final List<Map<String,IntStruct>> list;
+
+	@Position(1)
+	private final String validationValue;
+
+	public ListMapStruct(List<Map<String,IntStruct>> list, String validationValue) {
+		this.list = list;
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public List<Map<String,IntStruct>> getValue() {
+		return list;
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		return list.stream()
+				.map(m -> toPrintableMap(m))
+				.collect(Collectors.toList())
+				.toString();
+	}
+
+	private Map<String, String> toPrintableMap(Map<String, IntStruct> m) {
+		return m.entrySet().stream()
+				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toSimpleString()));
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return list.isEmpty();
+	}
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListStructPrimitive.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListStructPrimitive.java
@@ -1,0 +1,53 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+public final class ListStructPrimitive extends Struct implements IEmptyCollectionStruct<List<Integer>> {
+
+	@Position(0)
+	private final List<Integer> list;
+
+	@Position(1)
+	private final String validationValue;
+
+	public ListStructPrimitive(List<Integer> list, String validationValue) {
+		this.list = list;
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public List<Integer> getValue() {
+		return list;
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		return list.stream().map(i -> i.toString()).collect(Collectors.joining(","));
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return list.isEmpty();
+	}
+
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListStructStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListStructStruct.java
@@ -1,0 +1,55 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
+
+public final class ListStructStruct extends Struct implements IEmptyCollectionStruct<List<IntStruct>> {
+
+	@Position(0)
+	private final List<IntStruct> list;
+
+	@Position(1)
+	private final String validationValue;
+
+	public ListStructStruct(List<IntStruct> list, String validationValue) {
+		this.list = list;
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public List<IntStruct> getValue() {
+		return list;
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		return list.stream()
+				.map(i -> i.toSimpleString())
+				.collect(Collectors.joining(","));
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return list.isEmpty();
+	}
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/MapArrayStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/MapArrayStruct.java
@@ -1,0 +1,62 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
+
+public final class MapArrayStruct extends Struct implements IEmptyCollectionStruct<Map<String,IntStruct[]>> {
+
+	@Position(0)
+	private final Map<String,IntStruct[]> map;
+
+	@Position(1)
+	private final String validationValue;
+
+	public MapArrayStruct(Map<String,IntStruct[]> map, String validationValue) {
+		this.map = map;
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public Map<String,IntStruct[]> getValue() {
+		return map;
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		return map.entrySet().stream()
+				.collect(Collectors.toMap(e -> e.getKey(), e -> toPrintableArray(e.getValue())))
+				.toString();
+	}
+
+	private String toPrintableArray(IntStruct[] array) {
+		String values = Stream.of(array).map(e -> e.toSimpleString())
+				.collect(Collectors.joining(","));
+		return String.format("[%s]", values);
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
+	}
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/MapStructIntStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/MapStructIntStruct.java
@@ -1,0 +1,58 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
+
+
+public final class MapStructIntStruct extends Struct implements IEmptyCollectionStruct<Map<String, IntStruct>> {
+
+	@Position(0)
+	private final Map<String, IntStruct> map;
+
+	@Position(1)
+	private final String validationValue;
+
+	public MapStructIntStruct(Map<String, IntStruct> map, String validationValue) {
+		this.map = map;
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public Map<String, IntStruct> getValue() {
+		return map;
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		String values = map.entrySet().stream()
+				.map(e -> String.format("%s:%s", e.getKey(), e.getValue().toSimpleString()))
+				.collect(Collectors.joining(","));
+		return String.format("{%s}", values);
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
+	}
+
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/MapStructPrimitive.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/MapStructPrimitive.java
@@ -1,0 +1,57 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.collections.empty.structs;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+
+public final class MapStructPrimitive extends Struct implements IEmptyCollectionStruct<Map<String, Integer>> {
+
+	@Position(0)
+	private final Map<String, Integer> map;
+
+	@Position(1)
+	private final String validationValue;
+
+	public MapStructPrimitive(Map<String, Integer> map, String validationValue) {
+		this.map = map;
+		this.validationValue = validationValue;
+	}
+
+	@Override
+	public Map<String, Integer> getValue() {
+		return map;
+	}
+
+	@Override
+	public String getValidationValue() {
+		return validationValue;
+	}
+
+	@Override
+	public String getStringTestValue() {
+		String values = map.entrySet().stream()
+				.map(e -> String.format("%s:%s", e.getKey(), e.getValue()))
+				.collect(Collectors.joining(","));
+		return String.format("{%s}", values);
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
+	}
+
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/P2pTestServer.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/P2pTestServer.java
@@ -22,7 +22,9 @@ import java.util.Map;
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DirectConnection;
 import org.freedesktop.dbus.test.helper.interfaces.SampleRemoteInterface;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
 import org.freedesktop.dbus.test.helper.structs.SampleStruct3;
+import org.freedesktop.dbus.test.helper.structs.SampleStruct4;
 import org.freedesktop.dbus.types.UInt16;
 
 public class P2pTestServer implements SampleRemoteInterface {
@@ -38,6 +40,18 @@ public class P2pTestServer implements SampleRemoteInterface {
         }
         return out;
     }
+    
+    @Override
+	public int[][] testListstruct(SampleStruct4 in) {
+		List<IntStruct> list = in.getInnerListOfLists();
+		int size = list.size();
+		int[][] retVal = new int [size][];
+		for(int i = 0; i < size; i++) {
+			IntStruct elem = list.get(i);
+			retVal[i] = new int [] { elem.getValue1(), elem.getValue2()}; 
+		}
+		return retVal;
+	}
 
     @Override
     public String getNameAndThrow() {

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/SampleClass.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/SampleClass.java
@@ -22,8 +22,10 @@ import org.freedesktop.dbus.test.TestAll;
 import org.freedesktop.dbus.test.helper.interfaces.SampleNewInterface;
 import org.freedesktop.dbus.test.helper.interfaces.SampleRemoteInterface;
 import org.freedesktop.dbus.test.helper.interfaces.SampleRemoteInterface2;
+import org.freedesktop.dbus.test.helper.structs.IntStruct;
 import org.freedesktop.dbus.test.helper.structs.SampleStruct;
 import org.freedesktop.dbus.test.helper.structs.SampleStruct3;
+import org.freedesktop.dbus.test.helper.structs.SampleStruct4;
 import org.freedesktop.dbus.test.helper.structs.SampleTuple;
 import org.freedesktop.dbus.types.UInt16;
 import org.freedesktop.dbus.types.UInt32;
@@ -53,6 +55,18 @@ public class SampleClass implements SampleRemoteInterface, SampleRemoteInterface
         }
         return out;
     }
+    
+    @Override
+	public int[][] testListstruct(SampleStruct4 in) {
+		List<IntStruct> list = in.getInnerListOfLists();
+		int size = list.size();
+		int[][] retVal = new int [size][];
+		for(int i = 0; i < size; i++) {
+			IntStruct elem = list.get(i);
+			retVal[i] = new int [] { elem.getValue1(), elem.getValue2()}; 
+		}
+		return retVal;
+	}
 
     @Override
     public float testfloat(float[] f) {

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/interfaces/SampleRemoteInterface.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/interfaces/SampleRemoteInterface.java
@@ -22,6 +22,7 @@ import org.freedesktop.dbus.annotations.MethodNoReply;
 import org.freedesktop.dbus.interfaces.DBusInterface;
 import org.freedesktop.dbus.test.helper.SampleException;
 import org.freedesktop.dbus.test.helper.structs.SampleStruct3;
+import org.freedesktop.dbus.test.helper.structs.SampleStruct4;
 import org.freedesktop.dbus.types.UInt16;
 
 /**
@@ -70,4 +71,7 @@ public interface SampleRemoteInterface extends DBusInterface {
     List<DBusPath> pathlistrv(List<DBusPath> a);
 
     Map<DBusPath, DBusPath> pathmaprv(Map<DBusPath, DBusPath> a);
+
+    @IntrospectionDescription("Some function to test collections")
+	int[][] testListstruct(SampleStruct4 in);
 }

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/structs/IntStruct.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/structs/IntStruct.java
@@ -1,0 +1,40 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV 
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.helper.structs;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+public final class IntStruct extends Struct {
+    
+	@Position(0)
+    private final int value1;
+    
+    @Position(1)
+    private final int value2;
+
+	public IntStruct(int value1, int value2) {
+		this.value1 = value1;
+		this.value2 = value2;
+	}
+
+	public int getValue1() {
+		return value1;
+	}
+
+	public int getValue2() {
+		return value2;
+	}
+	
+	public String toSimpleString() {
+		return String.format("(%s,%s)", value1, value2);
+	}
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/structs/SampleStruct4.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/structs/SampleStruct4.java
@@ -1,0 +1,32 @@
+/*
+   D-Bus Java Implementation
+   Copyright (c) 2019 Technolution BV 
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of either the GNU Lesser General Public License Version 2 or the
+   Academic Free Licence Version 2.1.
+
+   Full licence texts are included in the LICENSE file with this program.
+*/
+
+package org.freedesktop.dbus.test.helper.structs;
+
+import java.util.List;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+
+public final class SampleStruct4 extends Struct {
+    @Position(0)
+    private final List<IntStruct> innerListOfLists;
+
+	public SampleStruct4(List<IntStruct> innerListOfLists) {
+		this.innerListOfLists = innerListOfLists;
+	}
+
+	public List<IntStruct> getInnerListOfLists() {
+		return innerListOfLists;
+	}
+
+}


### PR DESCRIPTION
The following this have been fixed/added by this pull request:

- Allow empty collections for :
  - Lists
  - Arrays
  - Maps (improved)
- Fix TCP Transport. This wasn't working anymore after splitting it into Unix and TCP Transport
- Added system variable 'DBUS_MACHINE_ID_LOCATION' to allow custom file locations

The last two fixes are necessary for DBUS in a windows environment,  
