### PR TITLE
Allow to configure timeout on sockets

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
@@ -75,13 +75,13 @@ public abstract class AbstractConnection implements Closeable {
 
     private static final Map<Thread, DBusCallInfo> INFOMAP     = new ConcurrentHashMap<>();
     /**
-     * Timeout in µs on checking the BUS for incoming messages and sending outgoing messages
-     */
-    private static final int                       TIMEOUT     = 100000;
-    /**
      * Default thread pool size
      */
     private static final int         THREADCOUNT = 4;
+    /**
+     * Timeout in µs on checking the BUS for incoming messages and sending outgoing messages
+     */
+    protected static final int                       TIMEOUT     = 100000;
 
     public static final boolean      FLOAT_SUPPORT    =    (null != System.getenv("DBUS_JAVA_FLOATS"));
     public static final String       BUSNAME_REGEX    = "^[-_a-zA-Z][-_a-zA-Z0-9]*(\\.[-_a-zA-Z][-_a-zA-Z0-9]*)*$";

--- a/dbus-java/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
@@ -124,6 +124,10 @@ public abstract class AbstractConnection implements Closeable {
     private ExecutorService                                                    senderService;
 
     protected AbstractConnection(String address) throws DBusException {
+        this(address, AbstractConnection.TIMEOUT);
+    }
+    
+    protected AbstractConnection(String address, int timeout) throws DBusException {
         exportedObjects = new HashMap<>();
         importedObjects = new ConcurrentHashMap<>();
 
@@ -148,7 +152,7 @@ public abstract class AbstractConnection implements Closeable {
 
         try {
             busAddress = new BusAddress(address);
-            transport = TransportFactory.createTransport(busAddress, AbstractConnection.TIMEOUT);
+            transport = TransportFactory.createTransport(busAddress, timeout);
             connected = true;
         } catch (IOException | DBusException ioe) {
             logger.debug("Error creating transport", ioe);

--- a/dbus-java/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
@@ -49,13 +49,24 @@ import com.github.hypfvieh.util.StringUtil;
 public class DirectConnection extends AbstractConnection {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final String machineId;
+    
+    /**
+     * Create a direct connection to another application.
+     * @param address The address to connect to. This is a standard D-Bus address, except that the additional parameter 'listen=true' should be added in the application which is creating the socket.
+     * @throws DBusException on error
+     */
+    public DirectConnection(String address) throws DBusException {
+        this(address, AbstractConnection.TIMEOUT);
+    }
+    
     /**
     * Create a direct connection to another application.
     * @param address The address to connect to. This is a standard D-Bus address, except that the additional parameter 'listen=true' should be added in the application which is creating the socket.
+    * @param timeout the timeout set for the underlying socket. 0 will block forever on the underlying socket. 
     * @throws DBusException on error
     */
-    public DirectConnection(String address) throws DBusException {
-        super(address);
+    public DirectConnection(String address, int timeout) throws DBusException {
+        super(address, timeout);
         machineId = createMachineId();
         if (!getAddress().isServer()) {
             super.listen();

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/LowLevelTest.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/LowLevelTest.java
@@ -13,6 +13,7 @@ import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.messages.DBusSignal;
 import org.freedesktop.dbus.messages.Message;
 import org.freedesktop.dbus.messages.MethodCall;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +24,26 @@ import com.github.hypfvieh.util.StringUtil;
 public class LowLevelTest {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
+    @Test
+    public void testTimeout() throws ParseException, IOException, DBusException {
+        String addr = getAddress();
+        logger.debug(addr);
+        BusAddress address = new BusAddress(addr);
+        logger.debug(address + "");
+        int timeout = 100;
+		try (AbstractTransport conn = TransportFactory.createTransport(address, timeout)) {
+        	long before = System.currentTimeMillis();
+        	conn.readMessage();
+        	long after = System.currentTimeMillis();
+        	long timeOutMeasured = after - before;
+			Assertions.assertTrue(timeOutMeasured >= timeout, "To early unblocked");
+			//There is no strict limit on this however the 2 times is a safe limit
+			Assertions.assertTrue(timeOutMeasured < timeout * 2, "Blocking to long");
+			System.out.println(timeOutMeasured);
+        }
+    }
+    
+    
     @Test
     public void testLowLevel() throws ParseException, IOException, DBusException {
         String addr = getAddress();


### PR DESCRIPTION
This change allows to set the Timeout of the underlying sockets. 

Currently this change is used as a workaround to prevent socket timeouts breaking the connection.
The library actually needs a bigger change to enable recovery of broken sockets. 