### PR TITLE
Listen for more arbitrary signals

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/SignalTuple.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/SignalTuple.java
@@ -12,6 +12,9 @@
 
 package org.freedesktop.dbus;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class SignalTuple {
     private String type;
     private String name;
@@ -66,5 +69,49 @@ public class SignalTuple {
     @Override
     public String toString() {
         return "SignalTuple(" + type + "," + name + "," + object + "," + source + ")";
+    }
+
+    /**
+     * Get an array of all possible SignalTuples that we can have, given the 4 parameters.
+     */
+    public static Set<SignalTuple> getAllPossibleTuples(String _type, String _name, String _object, String _source){
+        Set<SignalTuple> allTuples = new HashSet<>();
+
+        // Tuple with no null
+        allTuples.add( new SignalTuple(_type, _name, _object, _source) );
+
+        // Tuples with one null
+        allTuples.add( new SignalTuple(null, _name, _object, _source) );
+        allTuples.add( new SignalTuple(_type, null, _object, _source) );
+        allTuples.add( new SignalTuple(_type, _name, null, _source) );
+        allTuples.add( new SignalTuple(_type, _name, _object, null) );
+
+        // Tuples where type is null, and one other null
+        allTuples.add( new SignalTuple(null, null, _object, _source) );
+        allTuples.add( new SignalTuple(null, _name, null, _source) );
+        allTuples.add( new SignalTuple(null, _name, _object, null) );
+
+        // Tuples where name is null, and one other null
+        allTuples.add( new SignalTuple(null, null, _object, _source) );
+        allTuples.add( new SignalTuple(_type, null, null, _source) );
+        allTuples.add( new SignalTuple(_type, null, _object, null) );
+
+        // Tuples where object is null, and one other null
+        allTuples.add( new SignalTuple(null, _name, null, _source) );
+        allTuples.add( new SignalTuple(_type, null, null, _source) );
+        allTuples.add( new SignalTuple(_type, _name, null, null) );
+
+        // Tuples where source is null, and one other null
+        allTuples.add( new SignalTuple(null, _name, _object, null) );
+        allTuples.add( new SignalTuple(_type, null, _object, null) );
+        allTuples.add( new SignalTuple(_type, _name, null, null) );
+
+        // Tuples with three nulls
+        allTuples.add( new SignalTuple(_type, null, null, null) );
+        allTuples.add( new SignalTuple(null, _name, null, null) );
+        allTuples.add( new SignalTuple(null, null, _object, null) );
+        allTuples.add( new SignalTuple(null, null, null, _source) );
+
+        return allTuples;
     }
 }

--- a/dbus-java/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
@@ -838,21 +838,12 @@ public abstract class AbstractConnection implements Closeable {
         }
         synchronized (getGenericHandledSignals()) {
             List<DBusSigHandler<DBusSignal>> t;
-            t = getGenericHandledSignals().get(new SignalTuple(_signal.getInterface(), _signal.getName(), null, null));
-            if (null != t) {
-                genericHandlers.addAll(t);
-            }
-            t = getGenericHandledSignals().get(new SignalTuple(_signal.getInterface(), _signal.getName(), _signal.getPath(), null));
-            if (null != t) {
-                genericHandlers.addAll(t);
-            }
-            t = getGenericHandledSignals().get(new SignalTuple(_signal.getInterface(), _signal.getName(), null, _signal.getSource()));
-            if (null != t) {
-                genericHandlers.addAll(t);
-            }
-            t = getGenericHandledSignals().get(new SignalTuple(_signal.getInterface(), _signal.getName(), _signal.getPath(), _signal.getSource()));
-            if (null != t) {
-                genericHandlers.addAll(t);
+            Set<SignalTuple> allTuples = SignalTuple.getAllPossibleTuples(_signal.getInterface(), _signal.getName(), _signal.getPath(), _signal.getSource());
+            for( SignalTuple tuple : allTuples ){
+                t = getGenericHandledSignals().get(tuple);
+                if (null != t) {
+                    genericHandlers.addAll(t);
+                }
             }
         }
         if (handlers.isEmpty() && genericHandlers.isEmpty()) {

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/TestAll.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/TestAll.java
@@ -229,6 +229,26 @@ public class TestAll {
     }
 
     @Test
+    public void testGenericHandlerWithNoInterface() throws DBusException, InterruptedException {
+        GenericHandlerWithDecode genericDecode = new GenericHandlerWithDecode(new UInt32(42), "SampleString");
+        DBusMatchRule signalRule = new DBusMatchRule("signal", null, "methodargNoIface", "/");
+
+        clientconn.addGenericSigHandler(signalRule, genericDecode);
+
+        DBusSignal signalToSend =
+                new DBusSignal(null, "/", "org.foo", "methodargNoIface", "us", new UInt32(42), "SampleString");
+
+        serverconn.sendMessage(signalToSend);
+
+        // wait some time to receive signals
+        Thread.sleep(1000L);
+
+        genericDecode.incomingSameAsExpected();
+
+        clientconn.removeGenericSigHandler(signalRule, genericDecode);
+    }
+
+    @Test
     public void testPing() throws DBusException {
         System.out.println("Pinging ourselves");
         Peer peer = clientconn.getRemoteObject("foo.bar.Test", TEST_OBJECT_PATH, Peer.class);
@@ -399,7 +419,7 @@ public class TestAll {
         assertEquals(elem2.getValue1(), out[1][0]);
         assertEquals(elem2.getValue2(), out[1][1]);
     }
-    
+
     public void testFrob() throws DBusException {
         SampleRemoteInterface tri = (SampleRemoteInterface) clientconn.getPeerRemoteObject("foo.bar.Test", TEST_OBJECT_PATH);
         System.out.println("frobnicating");

--- a/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/signals/handler/GenericHandlerWithDecode.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/test/helper/signals/handler/GenericHandlerWithDecode.java
@@ -5,6 +5,7 @@ import org.freedesktop.dbus.interfaces.DBusSigHandler;
 import org.freedesktop.dbus.messages.DBusSignal;
 import org.freedesktop.dbus.types.UInt32;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
@@ -38,6 +39,7 @@ public class GenericHandlerWithDecode implements DBusSigHandler<DBusSignal> {
     }
 
     public void incomingSameAsExpected(){
+        assertNotNull( parameters );
         assertEquals( parameters.length, 2 );
 
         if (expectedIntResult != null) {


### PR DESCRIPTION
When adding a generic signal handler, it is now possible to get a signal
back in your handler even if the interface is null.