### PR TITLE
Build dbus-java as bundle with embedded dependencies.

### DIFF
--- a/dbus-java/.gitignore
+++ b/dbus-java/.gitignore
@@ -1,1 +1,2 @@
 /target/
+META-INF/

--- a/dbus-java/pom.xml
+++ b/dbus-java/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <artifactId>dbus-java</artifactId>
 
@@ -49,6 +49,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <manifestLocation>META-INF</manifestLocation>
+                    <instructions>
+                      <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                      <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                      <Bundle-Name>${project.name}</Bundle-Name>
+                      <Bundle-Description>dbus-java</Bundle-Description>
+                      <Bundle-Vendor>JCI</Bundle-Vendor>
+                      <Bundle-Version>${project.version}</Bundle-Version>
+                      <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
+                      <Import-Package>
+                      org.slf4j,
+                      org.eclipse.jdt.annotation;resolution:=optional
+                      </Import-Package>
+                      <Export-Package>org.freedesktop.*</Export-Package>
+                      <Embed-Dependency>!junit-*,!slf4j*, !mockito*, !logback*, !apiguardian*, !opentest4j*, !objenesis, !org.eclipse.jdt.annotation*, !byte-buddy*, ;scope=compile|runtime</Embed-Dependency>
+                      <Embed-Transitive>true</Embed-Transitive>
+                    </instructions>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
@@ -106,6 +131,13 @@
     </build>
 
     <dependencies>
+    
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.annotation</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+    
         <dependency>
             <groupId>com.github.hypfvieh</groupId>
             <artifactId>java-utils</artifactId>


### PR DESCRIPTION
The challenge with building this project as an OSGi-enabled bundle is that many of the dependencies it
relies on are also not OSGi-enabled.  There are a couple ways to manage this, but the two broad categories
are to either make those dependency projects OSGi-enabled, or to take those projects as-is and embed
them in the bundle that is created.  This PR is one of two different proposals to build dbus-java as a bundle.
This version of pom.xml will embed all the dependencies needed for this bundle to be loaded and run,
including jffi-*.jar, jnr-*.jar, and asm-*.jar.  The benefit to this method is convenience for users
who want to reference this library an an OSGi environment-it's ready to
go.  The drawback is the bundle becomes "fat" by embedding other jar files in the bundle itself.