### PR TITLE
Authentication hangs when using TCP.

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/connections/SASL.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/connections/SASL.java
@@ -490,6 +490,7 @@ public class SASL {
                                 send(out, SaslCommand.NEGOTIATE_UNIX_FD);
                             }else{
                                 state = SaslAuthState.FINISHED;
+                                send(out, BEGIN);                     
                             }
                             break;
                         case AGREE_UNIX_FD:
@@ -572,7 +573,8 @@ public class SASL {
                     case INITIAL_STATE:
                         byte[] buf = new byte[1];
                         if (null == us) {
-                            in.read(buf);
+                            in.read(buf); // 0
+                            state = SaslAuthState.WAIT_AUTH;
                         } else {
                             Credentials credentials;
                             try {


### PR DESCRIPTION
I am trying to use dbus-java as both a client and server on Windows. Windows does not support Unix sockets, so TCP must be used.

However, I found that authentication would always hang when using TCP. It was because :-

1) The zero byte at the start of the TCP conversation was being read, but the state flag was no moved on to the next state, so this read kept repeating sinking the actual command.
2) At the end of the authentication, BEGIN was not being sent.