### PR TITLE
Modularise dbus-java (MRJAR, so supports Java 8 and Java 9+).

### DIFF
--- a/dbus-java-osgi/pom.xml
+++ b/dbus-java-osgi/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.0</version>
+                <version>5.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <manifestLocation>META-INF</manifestLocation>

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/Caller.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/Caller.java
@@ -10,7 +10,7 @@
    Full licence texts are included in the LICENSE file with this program.
 */
 
-package org.freedesktop.dbus.bin;
+package org.freedesktop.dbus.utils.bin;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/CreateInterface.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/CreateInterface.java
@@ -10,9 +10,9 @@
    Full licence texts are included in the LICENSE file with this program.
 */
 
-package org.freedesktop.dbus.bin;
+package org.freedesktop.dbus.utils.bin;
 
-import static org.freedesktop.dbus.bin.IdentifierMangler.mangle;
+import static org.freedesktop.dbus.utils.bin.IdentifierMangler.mangle;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -680,7 +680,7 @@ public class CreateInterface {
 
     private final PrintStreamFactory factory;
 
-    static class Config {
+    public static class Config {
         // CHECKSTYLE:OFF
         DBusBusType     bus       = DBusBusType.SESSION;
         String  busname   = null;

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/IdentifierMangler.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/IdentifierMangler.java
@@ -10,7 +10,7 @@
    Full licence texts are included in the LICENSE file with this program.
 */
 
-package org.freedesktop.dbus.bin;
+package org.freedesktop.dbus.utils.bin;
 
 import java.util.Arrays;
 

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/IterableNodeList.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/IterableNodeList.java
@@ -10,37 +10,22 @@
    Full licence texts are included in the LICENSE file with this program.
 */
 
-package org.freedesktop.dbus.bin;
+package org.freedesktop.dbus.utils.bin;
 
 import java.util.Iterator;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-class NodeListIterator implements Iterator<Node> {
-    // CHECKSTYLE:OFF
-    NodeList nl;
-    int      i;
-    // CHECKSTYLE:ON
+class IterableNodeList implements Iterable<Node> {
+    private NodeList nl;
 
-    NodeListIterator(NodeList _nl) {
+    IterableNodeList(NodeList _nl) {
         this.nl = _nl;
-        i = 0;
     }
 
     @Override
-    public boolean hasNext() {
-        return i < nl.getLength();
+    public Iterator<Node> iterator() {
+        return new NodeListIterator(nl);
     }
-
-    @Override
-    public Node next() {
-        Node n = nl.item(i);
-        i++;
-        return n;
-    }
-
-    @Override
-    public void remove() {
-    };
 }

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/ListDBus.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/ListDBus.java
@@ -10,7 +10,7 @@
    Full licence texts are included in the LICENSE file with this program.
 */
 
-package org.freedesktop.dbus.bin;
+package org.freedesktop.dbus.utils.bin;
 
 import org.freedesktop.DBus;
 import org.freedesktop.dbus.connections.impl.DBusConnection;

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/NodeListIterator.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/NodeListIterator.java
@@ -10,22 +10,37 @@
    Full licence texts are included in the LICENSE file with this program.
 */
 
-package org.freedesktop.dbus.bin;
+package org.freedesktop.dbus.utils.bin;
 
 import java.util.Iterator;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-class IterableNodeList implements Iterable<Node> {
-    private NodeList nl;
+class NodeListIterator implements Iterator<Node> {
+    // CHECKSTYLE:OFF
+    NodeList nl;
+    int      i;
+    // CHECKSTYLE:ON
 
-    IterableNodeList(NodeList _nl) {
+    NodeListIterator(NodeList _nl) {
         this.nl = _nl;
+        i = 0;
     }
 
     @Override
-    public Iterator<Node> iterator() {
-        return new NodeListIterator(nl);
+    public boolean hasNext() {
+        return i < nl.getLength();
     }
+
+    @Override
+    public Node next() {
+        Node n = nl.item(i);
+        i++;
+        return n;
+    }
+
+    @Override
+    public void remove() {
+    };
 }

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/PrintStreamFactory.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/PrintStreamFactory.java
@@ -1,4 +1,4 @@
-package org.freedesktop.dbus.bin;
+package org.freedesktop.dbus.utils.bin;
 
 import java.io.IOException;
 import java.io.PrintStream;

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/StructStruct.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/bin/StructStruct.java
@@ -10,7 +10,7 @@
    Full licence texts are included in the LICENSE file with this program.
 */
 
-package org.freedesktop.dbus.bin;
+package org.freedesktop.dbus.utils.bin;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/viewer/StringStreamFactory.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/viewer/StringStreamFactory.java
@@ -16,7 +16,7 @@ import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.freedesktop.dbus.bin.PrintStreamFactory;
+import org.freedesktop.dbus.utils.bin.PrintStreamFactory;
 
 /**
  * A factory using a byte array input stream

--- a/dbus-java-utils/src/main/java9/module-info.java
+++ b/dbus-java-utils/src/main/java9/module-info.java
@@ -1,0 +1,8 @@
+module org.freedesktop.dbus.utils {
+	exports org.freedesktop.dbus.utils.bin;
+	exports org.freedesktop.dbus.utils.generator;
+	exports org.freedesktop.dbus.viewer;
+	requires transitive org.freedesktop.dbus;
+	requires java.xml;
+	requires java.desktop;
+}

--- a/dbus-java-utils/src/main/java9/module-info.java
+++ b/dbus-java-utils/src/main/java9/module-info.java
@@ -1,8 +1,8 @@
 module org.freedesktop.dbus.utils {
-	exports org.freedesktop.dbus.utils.bin;
-	exports org.freedesktop.dbus.utils.generator;
-	exports org.freedesktop.dbus.viewer;
-	requires transitive org.freedesktop.dbus;
-	requires java.xml;
-	requires java.desktop;
+    exports org.freedesktop.dbus.utils.bin;
+    exports org.freedesktop.dbus.utils.generator;
+    exports org.freedesktop.dbus.viewer;
+    requires transitive org.freedesktop.dbus;
+    requires java.xml;
+    requires java.desktop;
 }

--- a/dbus-java/src/main/java/org/freedesktop/dbus/bin/DBusDaemon.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/bin/DBusDaemon.java
@@ -65,7 +65,7 @@ public class DBusDaemon extends Thread implements Closeable {
 
     private static final Logger LOGGER          = LoggerFactory.getLogger(DBusDaemon.class);
 
-    static class Connstruct {
+    public static class Connstruct {
         // CHECKSTYLE:OFF
         public UnixSocket    usock;
         public Socket        tsock;

--- a/dbus-java/src/main/java9/module-info.java
+++ b/dbus-java/src/main/java9/module-info.java
@@ -1,0 +1,25 @@
+module org.freedesktop.dbus {
+	exports org.freedesktop;
+	exports org.freedesktop.dbus;
+	exports org.freedesktop.dbus.bin;
+	exports org.freedesktop.dbus.annotations;
+	exports org.freedesktop.dbus.connections;
+	exports org.freedesktop.dbus.connections.impl;
+	exports org.freedesktop.dbus.connections.transports;
+	exports org.freedesktop.dbus.errors;
+	exports org.freedesktop.dbus.exceptions;
+	exports org.freedesktop.dbus.handlers;
+	exports org.freedesktop.dbus.interfaces;
+	exports org.freedesktop.dbus.messages;
+	exports org.freedesktop.dbus.spi;
+	exports org.freedesktop.dbus.types;
+	exports org.freedesktop.dbus.utils;
+	requires transitive org.slf4j;
+	requires transitive org.jnrproject.unixsocket;
+	requires transitive java.utils;
+	requires transitive org.jnrproject.posix;
+	requires transitive org.jnrproject.constants;
+	requires transitive org.jnrproject.ffi;
+	requires transitive org.jnrproject.enxio;
+	uses org.freedesktop.dbus.spi.ISocketProvider;
+}

--- a/dbus-java/src/main/java9/module-info.java
+++ b/dbus-java/src/main/java9/module-info.java
@@ -1,25 +1,27 @@
 module org.freedesktop.dbus {
-	exports org.freedesktop;
-	exports org.freedesktop.dbus;
-	exports org.freedesktop.dbus.bin;
-	exports org.freedesktop.dbus.annotations;
-	exports org.freedesktop.dbus.connections;
-	exports org.freedesktop.dbus.connections.impl;
-	exports org.freedesktop.dbus.connections.transports;
-	exports org.freedesktop.dbus.errors;
-	exports org.freedesktop.dbus.exceptions;
-	exports org.freedesktop.dbus.handlers;
-	exports org.freedesktop.dbus.interfaces;
-	exports org.freedesktop.dbus.messages;
-	exports org.freedesktop.dbus.spi;
-	exports org.freedesktop.dbus.types;
-	exports org.freedesktop.dbus.utils;
-	requires transitive org.slf4j;
-	requires transitive org.jnrproject.unixsocket;
-	requires transitive java.utils;
-	requires transitive org.jnrproject.posix;
-	requires transitive org.jnrproject.constants;
-	requires transitive org.jnrproject.ffi;
-	requires transitive org.jnrproject.enxio;
-	uses org.freedesktop.dbus.spi.ISocketProvider;
+    exports org.freedesktop;
+    exports org.freedesktop.dbus;
+    exports org.freedesktop.dbus.bin;
+    exports org.freedesktop.dbus.annotations;
+    exports org.freedesktop.dbus.connections;
+    exports org.freedesktop.dbus.connections.impl;
+    exports org.freedesktop.dbus.connections.transports;
+    exports org.freedesktop.dbus.errors;
+    exports org.freedesktop.dbus.exceptions;
+    exports org.freedesktop.dbus.handlers;
+    exports org.freedesktop.dbus.interfaces;
+    exports org.freedesktop.dbus.messages;
+    exports org.freedesktop.dbus.spi;
+    exports org.freedesktop.dbus.types;
+    exports org.freedesktop.dbus.utils;
+
+    requires transitive org.slf4j;
+    requires transitive org.jnrproject.unixsocket;
+    requires transitive java.utils;
+    requires transitive org.jnrproject.posix;
+    requires transitive org.jnrproject.constants;
+    requires transitive org.jnrproject.ffi;
+    requires transitive org.jnrproject.enxio;
+
+    uses org.freedesktop.dbus.spi.ISocketProvider;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <description>DBus-Java library module parent</description>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>9</maven.compiler.source>
+        <maven.compiler.target>9</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit5.version>5.7.0</junit5.version>
     </properties>
@@ -61,10 +61,10 @@
                 </executions>
             </plugin>
             
-            <plugin>
+           <!--  <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.18</version>
+                <version>1.19</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -81,7 +81,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
@@ -113,6 +113,9 @@
                             <manifest>
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             </manifest>
+							<manifestEntries>
+								<Multi-Release>true</Multi-Release>
+							</manifestEntries>
                         </archive>
                     </configuration>
                 </plugin>
@@ -129,6 +132,39 @@
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>
+                
+                <plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.1</version>
+					<executions>
+						<execution>
+							<id>compile8</id>
+							<goals>
+								<goal>compile</goal>
+							</goals>
+							<configuration>
+								<source>1.8</source>
+								<target>1.8</target>
+							</configuration>
+						</execution>
+						<execution>
+							<id>compile9</id>
+							<phase>compile</phase>
+							<goals>
+								<goal>compile</goal>
+							</goals>
+							<configuration>
+								<release>9</release>
+								<compileSourceRoots>
+									<compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+									<compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+								</compileSourceRoots>
+								<multiReleaseOutput>true</multiReleaseOutput>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
             </plugins>
             
         </pluginManagement>
@@ -149,21 +185,22 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.30</version>
-            </dependency>
+			    <groupId>org.slf4j</groupId>
+			    <artifactId>slf4j-api</artifactId>
+			    <version>2.0.0-alpha1</version>
+			</dependency>
+
 
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.2.3</version>
+    			<version>1.3.0-alpha5</version>
             </dependency>
 
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.2.3</version>
+   				<version>1.3.0-alpha5</version>
             </dependency>
 
             <!-- JUnit testing framework. -->
@@ -197,12 +234,18 @@
                 <groupId>com.github.hypfvieh</groupId>
                 <artifactId>java-utils</artifactId>
                 <version>1.0.6</version>
+		<exclusions>
+	    	    <exclusion>
+			    <groupId>org.slf4j</groupId>
+			    <artifactId>slf4j-api</artifactId>
+		    </exclusion>
+		</exclusions>
             </dependency>
             
             <dependency>
                 <groupId>com.github.jnr</groupId>
                 <artifactId>jnr-unixsocket</artifactId>
-                <version>0.33</version>
+    			<version>0.38.5</version>
             </dependency>
 
         </dependencies>        

--- a/pom.xml
+++ b/pom.xml
@@ -113,9 +113,9 @@
                             <manifest>
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             </manifest>
-							<manifestEntries>
-								<Multi-Release>true</Multi-Release>
-							</manifestEntries>
+                            <manifestEntries>
+                                <Multi-Release>true</Multi-Release>
+                            </manifestEntries>
                         </archive>
                     </configuration>
                 </plugin>
@@ -134,37 +134,37 @@
                 </plugin>
                 
                 <plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.8.1</version>
-					<executions>
-						<execution>
-							<id>compile8</id>
-							<goals>
-								<goal>compile</goal>
-							</goals>
-							<configuration>
-								<source>1.8</source>
-								<target>1.8</target>
-							</configuration>
-						</execution>
-						<execution>
-							<id>compile9</id>
-							<phase>compile</phase>
-							<goals>
-								<goal>compile</goal>
-							</goals>
-							<configuration>
-								<release>9</release>
-								<compileSourceRoots>
-									<compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
-									<compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
-								</compileSourceRoots>
-								<multiReleaseOutput>true</multiReleaseOutput>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                    <executions>
+                        <execution>
+                            <id>compile8</id>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <source>1.8</source>
+                                <target>1.8</target>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>compile9</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <release>9</release>
+                                <compileSourceRoots>
+                                    <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+                                    <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                                </compileSourceRoots>
+                                <multiReleaseOutput>true</multiReleaseOutput>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
             
         </pluginManagement>
@@ -185,22 +185,21 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-			    <groupId>org.slf4j</groupId>
-			    <artifactId>slf4j-api</artifactId>
-			    <version>2.0.0-alpha1</version>
-			</dependency>
-
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.30</version>
+            </dependency>
 
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-    			<version>1.3.0-alpha5</version>
+                <version>1.3.0-alpha5</version>
             </dependency>
 
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-   				<version>1.3.0-alpha5</version>
+                <version>1.3.0-alpha5</version>
             </dependency>
 
             <!-- JUnit testing framework. -->
@@ -234,18 +233,18 @@
                 <groupId>com.github.hypfvieh</groupId>
                 <artifactId>java-utils</artifactId>
                 <version>1.0.6</version>
-		<exclusions>
-	    	    <exclusion>
-			    <groupId>org.slf4j</groupId>
-			    <artifactId>slf4j-api</artifactId>
-		    </exclusion>
-		</exclusions>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             
             <dependency>
                 <groupId>com.github.jnr</groupId>
                 <artifactId>jnr-unixsocket</artifactId>
-    			<version>0.38.5</version>
+                <version>0.38.5</version>
             </dependency>
 
         </dependencies>        


### PR DESCRIPTION
Now that JNR at least uses Automatic-Module-Name, dbus-java itself can modularised.  The largest change was the need to rename org.freedesktop.dbus.bin to org.freedesktop.dbus.utils.bin. No more than one particular module may export the same package, and both dbus-java-utils and dbus-java tried to export org.freedesktop.dbus.bin.

I should also point our that having classes in the org.freedesktop namespace is probably a bad idea (org.freedesktop.DBus and org.freedesktop.Hexdump classes), as this would mean that no modular project could use dbus-java and another module that happens to export org.freedesktop. One of my own projects did this (jfreedesktop), and exposed the issue. It can be left as org.freedesktop for now, but to be a good modular citizen this should be changed.

The other modular imperfection is `java.utils`. This is using an automatic module name, and should itself be modularised.

The Jar produced by the build is a multi-release Jar. So the bulk of it is compiled to Java 8, but Java 9 code is also compiled and placed in META-INF/versions/9. This is of course only used for module-info.class.

I had to disable `animal-sniffer-maven-plugin` to get this built. This doesn't appear to work with modules, and I can't find anything newer that 2017 for this apparently unmaintained plugin, so it may need to be removed. 

SLF4J also required use of an alpha version for module support. It appears otherwise stable.