### PR TITLE
I have come across systems that have existing but empty machine id fi…

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
@@ -312,7 +312,7 @@ public final class DBusConnection extends AbstractConnection {
 		return locationPriorityList.stream()
 				.filter(s -> s != null)
 				.map(s -> new File(s))
-				.filter(f -> f.exists())
+				.filter(f -> f.exists() && f.length() > 0)
 				.findFirst()
 				.orElseThrow(() -> new DBusException("Cannot Resolve Session Bus Address: MachineId file can not be found"));
 	}


### PR DESCRIPTION
I have come across systems that have existing but empty machine id files. For example, /var/lib/dbus/machine-id exists, but is empty, and /etc/machine-id exists and contains a UUID. This was on Debian Buster (no idea how how relevant this is).