### PR TITLE
Removed an offending method

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/messages/DBusSignal.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/messages/DBusSignal.java
@@ -372,11 +372,6 @@ public class DBusSignal extends Message {
         bodydone = true;
     }
 
-    @Override
-    public String toString() {
-        return "DBusSignal [clazz=" + clazz + "]";
-    }
-
     private static class CachedConstructor {
         private Constructor<? extends DBusSignal> constructor;
         private List<Class<?>>                    parameterTypes;


### PR DESCRIPTION
Removed a method that does not return any meaningful information and that overrides a very neat method in the Message superclass. All other Message class descendants do not override this method.