### PR TITLE
[#130] DBusProperty annotation added

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/TypeRef.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/TypeRef.java
@@ -1,0 +1,15 @@
+package org.freedesktop.dbus;
+
+/**
+ * Interface for retrieving generic type information with reflection.
+ * <p>
+ * Examples:
+ * <pre>{@code
+ * public interface ListOfStrings extends TypeRef<List<String>> {
+ * }
+ * } </pre>
+ *
+ * @param <T> generic type
+ */
+public interface TypeRef<T> {
+}

--- a/dbus-java/src/main/java/org/freedesktop/dbus/annotations/DBusProperties.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/annotations/DBusProperties.java
@@ -1,0 +1,24 @@
+package org.freedesktop.dbus.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Container for the multiple {@link DBusProperty} annotations in the single class.
+ * You probably don't want to use this annotation in your code, please use {@link DBusProperty}.
+ *
+ * @see DBusProperty
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DBusProperties {
+
+    /**
+     * Container for multiple properties
+     *
+     * @return value
+     */
+    DBusProperty[] value();
+}

--- a/dbus-java/src/main/java/org/freedesktop/dbus/annotations/DBusProperty.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/annotations/DBusProperty.java
@@ -1,0 +1,70 @@
+package org.freedesktop.dbus.annotations;
+
+import org.freedesktop.dbus.types.Variant;
+
+import java.lang.annotation.*;
+
+/**
+ * Appends information about properties in the interface. The annotated properties are added to the introspection data.
+ * In case of complex type of the property please use {@link org.freedesktop.dbus.TypeRef}.
+ * <p>
+ * Usage:
+ * </p>
+ * <pre>{@code
+ * @DBusInterfaceName("com.example.Bar")
+ * @DBusProperty(name = "Name", type = String.class)
+ * @DBusProperty(name = "ListOfVariables", type = List.class, access = Access.READ)
+ * @DBusProperty(name = "MapOfStringList", type = ComplexTypeWithMapAndList.class, access = Access.READ)
+ * public interface Bar extends DBusInterface {
+ *
+ *   // TypeRef allows to provide detailed information about type
+ *   interface ComplexTypeWithMapAndList extends TypeRef<Map<String, List<String>>> {
+ *   }
+ * }
+ * }</pre>
+ *
+ * @see org.freedesktop.dbus.interfaces.DBusInterface
+ * @see org.freedesktop.dbus.TypeRef
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(DBusProperties.class)
+public @interface DBusProperty {
+
+    /**
+     * Property name
+     *
+     * @return name
+     */
+    String name();
+
+    /**
+     * type of the property, in case of complex types please create custom interface that extends {@link org.freedesktop.dbus.TypeRef}
+     *
+     * @return type
+     */
+    Class<?> type() default Variant.class;
+
+    /**
+     * Property access type
+     *
+     * @return access
+     */
+    Access access() default Access.READ_WRITE;
+
+    enum Access {
+        READ("read"),
+        READ_WRITE("readwrite"),
+        WRITE("write");
+
+        private final String accessName;
+
+        Access(String accessName) {
+            this.accessName = accessName;
+        }
+
+        public String getAccessName() {
+            return accessName;
+        }
+    }
+}


### PR DESCRIPTION
Referring to the issue, this is my implementation proposal.
I tested the code with the following interface:
```java
import java.util.List;
import java.util.Map;
import org.freedesktop.dbus.ObjectPath;
import org.freedesktop.dbus.Struct;
import org.freedesktop.dbus.TypeRef;
import org.freedesktop.dbus.annotations.DBusInterfaceName;
import org.freedesktop.dbus.annotations.DBusProperty;
import org.freedesktop.dbus.annotations.DBusProperty.Access;
import org.freedesktop.dbus.annotations.Position;
import org.freedesktop.dbus.interfaces.DBusInterface;

@DBusInterfaceName("com.example.Bar")
@DBusProperty(name = "SimpleList1", type = List.class, access = Access.READ)
@DBusProperty(name = "SimpleMap", type = Map.class, access = Access.READ)
@DBusProperty(name = "ComplexMap", type = Bar.ComplexTypeWithMapAndList.class)
@DBusProperty(name = "Double", type = Double.class, access = Access.WRITE)
@DBusProperty(name = "DefaultType", access = Access.WRITE)
@DBusProperty(name = "Struct", type = Bar.MyStruct.class, access = Access.WRITE)
@DBusProperty(name = "Path", type = ObjectPath.class)
@DBusProperty(name = "Bool", type = Boolean.class)
@DBusProperty(name = "String2", type = Bar.StringRef.class)
public interface Bar extends DBusInterface {

  String method2(int arg);

  interface ComplexTypeWithMapAndList extends TypeRef<Map<String, List<String>>> {

  }

  interface StringRef extends TypeRef<String> {

  }

  class MyStruct extends Struct {

    @Position(0)
    private int i1;
    @Position(1)
    private int i2;
    @Position(2)
    private String name;
    @Position(3)
    private long number;
  }

}
```

MIT license is fine for me