### PR TITLE
InterfaceCodeGenerator - extended to generate DBusProperty annotations

### DIFF
--- a/dbus-java-utils/src/test/java/org/freedesktop/dbus/utils/generator/ClassBuilderInfoTest.java
+++ b/dbus-java-utils/src/test/java/org/freedesktop/dbus/utils/generator/ClassBuilderInfoTest.java
@@ -1,0 +1,52 @@
+package org.freedesktop.dbus.utils.generator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClassBuilderInfoTest {
+
+    @Test
+    void testGetSimpleTypeClasses() {
+        assertEquals("Class1", ClassBuilderInfo.getSimpleTypeClasses("Class1"));
+        assertEquals("Class1", ClassBuilderInfo.getSimpleTypeClasses("com.example.Class1"));
+        assertEquals("Map<Class1, List<String>>", ClassBuilderInfo.getSimpleTypeClasses("java.util.Map<com.example.Class1, java.util.List<java.lang.String>>"));
+        assertEquals("Map<Class1, List<String>>", ClassBuilderInfo.getSimpleTypeClasses("java.util.Map<Class1, java.util.List<java.lang.String>>"));
+        assertEquals("Map<Class1, List<String>>", ClassBuilderInfo.getSimpleTypeClasses("Map<com.example.Class1, java.util.List<java.lang.String>>"));
+        assertEquals("Map<Class1, List<String>>", ClassBuilderInfo.getSimpleTypeClasses("java.util.Map<com.example.Class1, List<String>>"));
+        assertEquals("Map<?, List<?>>", ClassBuilderInfo.getSimpleTypeClasses("java.util.Map<?, java.util.List<?>>"));
+    }
+
+    @Test
+    void testGetImportsForType() {
+        Set<String> imports;
+        imports = ClassBuilderInfo.getImportsForType("com.example.Class1");
+        assertEquals(1, imports.size());
+        assertTrue(imports.contains("com.example.Class1"));
+
+        // class in the same package, nothing to import
+        imports = ClassBuilderInfo.getImportsForType("Class1");
+        assertEquals(0, imports.size());
+
+        imports = ClassBuilderInfo.getImportsForType("java.lang.String");
+        assertEquals(0, imports.size());
+
+        imports = ClassBuilderInfo.getImportsForType("java.util.Map<com.example.Class1, java.util.List<java.lang.String>>");
+        assertEquals(3, imports.size());
+        assertTrue(imports.contains("java.util.Map"));
+        assertTrue(imports.contains("com.example.Class1"));
+        assertTrue(imports.contains("java.util.List"));
+
+        imports = ClassBuilderInfo.getImportsForType("java.util.Map<?, java.util.List<?>>");
+        assertEquals(2, imports.size());
+        assertTrue(imports.contains("java.util.Map"));
+        assertTrue(imports.contains("java.util.List"));
+
+        imports = ClassBuilderInfo.getImportsForType("java.util.List<Class1>");
+        assertEquals(1, imports.size());
+        assertTrue(imports.contains("java.util.List"));
+    }
+}


### PR DESCRIPTION
Following the new `@DBusProperty` annotation I extended the functionality of the InterfaceCodeGenerator tool.
The tool now recognizes the input `<property` tag and translates it into a corresponding `@DBusProperty` annotation.

I tested it with the input xml:
```xml
<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection
1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
<node>
 <interface name="com.example.Foo">
  <method name="method1" >
   <arg type="s" direction="out"/>
   <arg type="s" direction="in"/>
  </method>
 </interface>
 <interface name="com.example.Bar">
  <method name="method2" >
   <arg type="i" direction="in"/>
   <arg type="s" direction="out"/>
  </method>
  <property name="SimpleList1" type="av" access="read" />
  <property name="SimpleMap" type="a{vv}" access="read" />
  <property name="ComplexMap" type="a{sas}" access="readwrite" />
  <property name="Double" type="d" access="write" />
  <property name="DefaultType" type="v" access="write" />
  <property name="IISX" type="(iisx)" access="write" />
  <property name="ListOfISX" type="a(isx)" access="write" />
  <property name="Path" type="o" access="readwrite" />
  <property name="Bool" type="b" access="readwrite" />
  <property name="String2" type="s" access="readwrite" />
 </interface>
</node>
```
Of course the output file still needs some manual corrections such as removing unnecessary empty lines.