### PR TITLE
Export object using path from "getObjectPath" method

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -300,6 +301,21 @@ public abstract class AbstractConnection implements Closeable {
                 getObjectTree().add(objectpath, eo, eo.getIntrospectiondata());
             }
         }
+    }
+
+    /**
+     * Export an object so that its methods can be called on DBus. The path to the object will be taken from the
+     * {@link DBusInterface#getObjectPath()} method, make sure it is implemented and returns immutable value.
+     * If you want export object with multiple paths, please use {@link AbstractConnection#exportObject(String, DBusInterface)}.
+     *
+     * @param object
+     *            The object to export.
+     * @throws DBusException
+     *             If the object path is already exporting an object or if object path is incorrectly formatted.
+     */
+    public void exportObject(DBusInterface object) throws DBusException {
+        Objects.requireNonNull(object, "object must not be null");
+        exportObject(object.getObjectPath(), object);
     }
 
     /**

--- a/dbus-java/src/main/java/org/freedesktop/dbus/interfaces/DBusInterface.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/interfaces/DBusInterface.java
@@ -18,7 +18,9 @@ public interface DBusInterface {
      *
      * @return boolean
      */
-    boolean isRemote();
+    default boolean isRemote() {
+        return false;
+    }
 
     /**
      * Returns the path of this object.


### PR DESCRIPTION
This is my proposition to simplify API, we can export objects that describe their path with the `getObjectPath` method.
An example object class:
```java
public class SimpleObject implements Properties {

  private final String objectPath;

  public SimpleObject(String objectPath) {
    this.objectPath = objectPath;
  }

  @Override
  public String getObjectPath() {
    return objectPath;
  }

  @Override
  public <A> A Get(String interface_name, String property_name) {
    // ...
  }

  @Override
  public <A> void Set(String interface_name, String property_name, A value) {
    // ...
  }

  @Override
  public Map<String, Variant<?>> GetAll(String interface_name) {
    // ...
  }
}
```
We can easily export this object like this:
```java
DBusConnection conn = DBusConnection.getConnection(DBusBusType.SESSION);

SimpleObject simpleObject = new SimpleObject("/hal/module1");
conn.exportObject(simpleObject);
```

Additionally, I added the default result of the `isRemote` method.