### PR TITLE
User side errors added

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/AccessDenied.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/AccessDenied.java
@@ -5,7 +5,6 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException;
 /**
  * Thrown if a message is denied due to a security policy
  */
-@SuppressWarnings("serial")
 public class AccessDenied extends DBusExecutionException {
     public AccessDenied(String message) {
         super(message);

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/Error.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/Error.java
@@ -101,7 +101,7 @@ public class Error extends Message {
 
     @SuppressWarnings("unchecked")
     private static Class<? extends DBusExecutionException> createExceptionClass(String name) {
-        if (name == "org.freedesktop.DBus.Local.Disconnected") {
+        if ("org.freedesktop.DBus.Local.Disconnected".equals(name)) {
             return NotConnected.class;
         }
         Class<? extends DBusExecutionException> c = null;

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/InvalidArgs.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/InvalidArgs.java
@@ -1,0 +1,12 @@
+package org.freedesktop.dbus.errors;
+
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
+
+/**
+ * Thrown if a arguments passed to the method are invalid
+ */
+public class InvalidArgs extends DBusExecutionException {
+    public InvalidArgs(String message) {
+        super(message);
+    }
+}

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/MatchRuleInvalid.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/MatchRuleInvalid.java
@@ -5,7 +5,6 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException;
 /**
  * Thrown if the match rule is invalid
  */
-@SuppressWarnings("serial")
 public class MatchRuleInvalid extends DBusExecutionException {
     public MatchRuleInvalid(String message) {
         super(message);

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/NotSupported.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/NotSupported.java
@@ -1,0 +1,12 @@
+package org.freedesktop.dbus.errors;
+
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
+
+/**
+ * Thrown if a called operation is not supported
+ */
+public class NotSupported extends DBusExecutionException {
+    public NotSupported(String message) {
+        super(message);
+    }
+}

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/PropertyReadOnly.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/PropertyReadOnly.java
@@ -1,0 +1,12 @@
+package org.freedesktop.dbus.errors;
+
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
+
+/**
+ * Thrown if a attempt to edit read only property
+ */
+public class PropertyReadOnly extends DBusExecutionException {
+    public PropertyReadOnly(String message) {
+        super(message);
+    }
+}

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/ServiceUnknown.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/ServiceUnknown.java
@@ -5,7 +5,6 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException;
 /**
  * Thrown if the requested service was not available
  */
-@SuppressWarnings("serial")
 public class ServiceUnknown extends DBusExecutionException {
     public ServiceUnknown(String message) {
         super(message);

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/Timeout.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/Timeout.java
@@ -3,10 +3,10 @@ package org.freedesktop.dbus.errors;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 
 /**
- * Thrown if there is no reply to a method call
+ * Thrown if a operation timed out
  */
-public class NoReply extends DBusExecutionException {
-    public NoReply(String message) {
+public class Timeout extends DBusExecutionException {
+    public Timeout(String message) {
         super(message);
     }
 }

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/UnknownInterface.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/UnknownInterface.java
@@ -1,0 +1,12 @@
+package org.freedesktop.dbus.errors;
+
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
+
+/**
+ * Thrown if a interface does not exist
+ */
+public class UnknownInterface extends DBusExecutionException {
+    public UnknownInterface(String message) {
+        super(message);
+    }
+}

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/UnknownMethod.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/UnknownMethod.java
@@ -5,7 +5,6 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException;
 /**
  * Thrown if the method called was unknown on the remote object
  */
-@SuppressWarnings("serial")
 public class UnknownMethod extends DBusExecutionException {
     public UnknownMethod(String message) {
         super(message);

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/UnknownObject.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/UnknownObject.java
@@ -5,7 +5,6 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException;
 /**
  * Thrown if the object was unknown on a remote connection
  */
-@SuppressWarnings("serial")
 public class UnknownObject extends DBusExecutionException {
     public UnknownObject(String message) {
         super(message);

--- a/dbus-java/src/main/java/org/freedesktop/dbus/errors/UnknownProperty.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/errors/UnknownProperty.java
@@ -1,0 +1,12 @@
+package org.freedesktop.dbus.errors;
+
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
+
+/**
+ * Thrown if a property does not exist in the interface
+ */
+public class UnknownProperty extends DBusExecutionException {
+    public UnknownProperty(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
In these changes I added new exceptions that can be thrown from the user implementation level.
An example use case:
```java
public class SimpleObject implements Properties, HalModule 

  // ...

  @Override
  public <A> void Set(String interface_name, String property_name, A value) {
    if (/* interface does not exist */) {
      throw new UnknownInterface("Interface " + interface_name + " not found");
    }
    if (/* property does not exist */) {
      throw new UnknownProperty("Property " + property_name + " not found in " + interface_name);
    }
    if (/* property read-only */) {
      throw new PropertyReadOnly("Property " + property_name + " readonly");
    }
    // do update stuff
  }

  // ...

}
```
Additionally I removed redundant `@SuppressWarnings("serial")` error annotations.