### PR TITLE
Object.equals() on proxied interfaces will throw NPE if it is passed a null

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
@@ -181,7 +181,7 @@ public class RemoteInvocationHandler implements InvocationHandler {
         } else if (method.getName().equals("equals")) {
             try {
                 if (1 == args.length) {
-                    return Boolean.valueOf(remote.equals(((RemoteInvocationHandler) Proxy.getInvocationHandler(args[0])).remote));
+                    return Boolean.valueOf(( args[0] != null && remote.equals(((RemoteInvocationHandler) Proxy.getInvocationHandler(args[0])).remote)));
                 }
             } catch (IllegalArgumentException exIa) {
                 return Boolean.FALSE;


### PR DESCRIPTION
Minor bug fix. I found that comparing a proxied instance to `null` will throw a `NullPointerException`.