### PR TITLE
Mac OS X has unix domain sockets, but it does not have abstract paths, nor does machine ID detection work.

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
@@ -126,7 +126,7 @@ public class DirectConnection extends AbstractConnection {
             path = path.replaceAll("..........$", sb.toString());
             LoggerFactory.getLogger(DirectConnection.class).trace("Trying path {}", path);
         } while ((new File(path)).exists());
-        if (FreeBSDHelper.isFreeBSD()) {
+        if (FreeBSDHelper.isFreeBSD() || Util.isMacOs()) {
             address += "path=" + path;
         } else {
             address += "abstract=" + path;


### PR DESCRIPTION
Trying to use domain socket on OS X (client and embedded DBus server) fails because abstract paths are not supported. 

EDIT: Also, machine ID detection does not work on OS X, and is limited on Windows.