### PR TITLE
Fix for duplicated interfaces in the introspection data; missing DBus annotations fixed

### DIFF
--- a/dbus-java/src/main/java/org/freedesktop/dbus/utils/DBusNamingUtil.java
+++ b/dbus-java/src/main/java/org/freedesktop/dbus/utils/DBusNamingUtil.java
@@ -1,0 +1,83 @@
+package org.freedesktop.dbus.utils;
+
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * DBus name Util class for internal and external use.
+ */
+public final class DBusNamingUtil {
+    private static final Pattern DOLLAR_PATTERN = Pattern.compile("[$]");
+
+    private DBusNamingUtil() {
+    }
+
+    /**
+     * Get DBus interface name for specified interface class
+     *
+     * @param clazz input DBus interface class
+     * @return interface name
+     * @see DBusInterfaceName
+     */
+    public static String getInterfaceName(Class<?> clazz) {
+        Objects.requireNonNull(clazz, "clazz must not be null");
+
+        if (clazz.isAnnotationPresent(DBusInterfaceName.class)) {
+            return clazz.getAnnotation(DBusInterfaceName.class).value();
+        }
+        return DOLLAR_PATTERN.matcher(clazz.getName()).replaceAll(".");
+    }
+
+    /**
+     * Get DBus method name for specified method object.
+     *
+     * @param method input method
+     * @return method name
+     * @see DBusMemberName
+     */
+    public static String getMethodName(Method method) {
+        Objects.requireNonNull(method, "method must not be null");
+
+        if (method.isAnnotationPresent(DBusMemberName.class)) {
+            return method.getAnnotation(DBusMemberName.class).value();
+        }
+        return method.getName();
+    }
+
+    /**
+     * Get DBus signal name for specified signal class.
+     *
+     * @param clazz input DBus signal class
+     * @return signal name
+     * @see DBusMemberName
+     */
+    public static String getSignalName(Class<?> clazz) {
+        Objects.requireNonNull(clazz, "clazz must not be null");
+
+        if (clazz.isAnnotationPresent(DBusMemberName.class)) {
+            return clazz.getAnnotation(DBusMemberName.class).value();
+        }
+        return clazz.getSimpleName();
+    }
+
+    /**
+     * Get DBus name for specified annotation class
+     *
+     * @param clazz input DBus annotation
+     * @return interface name
+     * @see DBusInterfaceName
+     */
+    public static String getAnnotationName(Class<? extends Annotation> clazz) {
+        Objects.requireNonNull(clazz, "clazz must not be null");
+
+        if (clazz.isAnnotationPresent(DBusInterfaceName.class)) {
+            return clazz.getAnnotation(DBusInterfaceName.class).value();
+        }
+        return DOLLAR_PATTERN.matcher(clazz.getName()).replaceAll(".");
+    }
+}

--- a/dbus-java/src/test/java/org/freedesktop/dbus/utils/DBusNamingUtilTest.java
+++ b/dbus-java/src/test/java/org/freedesktop/dbus/utils/DBusNamingUtilTest.java
@@ -1,0 +1,71 @@
+package org.freedesktop.dbus.utils;
+
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
+import org.freedesktop.dbus.annotations.DeprecatedOnDBus;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DBusNamingUtilTest {
+
+    @Test
+    void getInterfaceNameTest() {
+        assertEquals("org.freedesktop.dbus.utils.DBusNamingUtilTest.Foo", DBusNamingUtil.getInterfaceName(Foo.class));
+        assertEquals("com.example.Bar", DBusNamingUtil.getInterfaceName(Bar.class));
+    }
+
+    @Test
+    void getMethodNameTest() throws NoSuchMethodException {
+        Method method1 = InterfaceWithMethodsAndSignals.class.getMethod("method1");
+        assertEquals("method1", DBusNamingUtil.getMethodName(method1));
+        Method method2 = InterfaceWithMethodsAndSignals.class.getMethod("method2");
+        assertEquals("methodAnnotationName", DBusNamingUtil.getMethodName(method2));
+    }
+
+    @Test
+    void getSignalNameTest() {
+        Class<? extends DBusSignal> signal1 = InterfaceWithMethodsAndSignals.Signal1.class;
+        assertEquals("Signal1", DBusNamingUtil.getSignalName(signal1));
+        Class<? extends DBusSignal> signal2 = InterfaceWithMethodsAndSignals.Signal2.class;
+        assertEquals("SignalAnnotationName", DBusNamingUtil.getSignalName(signal2));
+    }
+
+    @Test
+    void getAnnotationNameTest() {
+        assertEquals("org.freedesktop.DBus.Deprecated", DBusNamingUtil.getAnnotationName(DeprecatedOnDBus.class));
+    }
+
+    interface Foo extends DBusInterface {
+    }
+
+    @DBusInterfaceName("com.example.Bar")
+    interface Bar extends DBusInterface {
+    }
+
+    public interface InterfaceWithMethodsAndSignals extends DBusInterface {
+
+        void method1();
+
+        @DBusMemberName("methodAnnotationName")
+        void method2();
+
+        class Signal1 extends DBusSignal {
+            public Signal1(String objectPath, Object... args) throws DBusException {
+                super(objectPath, args);
+            }
+        }
+
+        @DBusMemberName("SignalAnnotationName")
+        class Signal2 extends DBusSignal {
+            public Signal2(String objectPath, Object... args) throws DBusException {
+                super(objectPath, args);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I would like to explain the problem with the duplicated interfaces in the introspection data with an example, let's suppose we have interfaces:

```java
@DBusInterfaceName("com.example.HalModule")
@DBusProperty(name = "Name", type = String.class, access = Access.READ)
@DBusProperty(name = "SerialNumber", type = String.class)
public interface HalModule extends DBusInterface {

  @DeprecatedOnDBus
  @IntrospectionDescription("Test description")
  void test();
}
```
```java
@DBusInterfaceName("com.example.PowerController")
@DBusProperty(name = "UnitStatus", type = String.class, access = Access.READ)
@DBusProperty(name = "Load", type = Double.class, access = Access.READ)
public interface PowerController extends DBusInterface {

}
```

Both interfaces have the `@DBusProperty` annotations - so we can expect an object that implements `HalModule` or `PowerController` to implement `Properties` as well.
Forcing the `Properties` implementation can be accomplished with extending it by `HalModule` and `PowerController` - maybe it was not the original assumption of interfaces behavior but it allows to simplify the application logic.
So the enriched interfaces will look like this:
```java
@DBusInterfaceName("com.example.HalModule")
@DBusProperty(name = "Name", type = String.class, access = Access.READ)
@DBusProperty(name = "SerialNumber", type = String.class)
public interface HalModule extends DBusInterface, Properties {

  @DeprecatedOnDBus
  @IntrospectionDescription("Test description")
  void test();
}
```
```java
@DBusInterfaceName("com.example.PowerController")
@DBusProperty(name = "UnitStatus", type = String.class, access = Access.READ)
@DBusProperty(name = "Load", type = Double.class, access = Access.READ)
public interface PowerController extends DBusInterface, Properties {

}
```
And DBus object class:
```java
public class PowerModuleObject implements PowerController, HalModule {
  //...
}
```
Currently this logic results in duplicated `Properties` interface in introspection data: 
![dbus_pr1](https://user-images.githubusercontent.com/29204450/117572345-c6cee280-b0d2-11eb-8289-1657c7fd50da.png)

This PR:
 * fixes the problem with duplicated interfaces in the introspection data
 * adds a new `DBusNamingUtil` class which will be helpful for internal and external use
 * fixes a bug with missing DBus annotations (eg `@DeprecatedOnDBus`, `@IntrospectionDescription`) in the introspection data