### PR TITLE
Fix signal interface generation

### DIFF
--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/ClassBuilderInfo.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/ClassBuilderInfo.java
@@ -263,8 +263,10 @@ public class ClassBuilderInfo {
                 String outerIndent = _staticClass ? "        " : "    ";
                 String cstr = outerIndent + "public " + getClassName() + "(";
 
-                if (!constructor.getSuperArguments().isEmpty()) {
-                    cstr += constructor.getSuperArguments().stream().map(e -> e.asOneLineString(allImports, false)).collect(Collectors.joining(", "));
+                List<ClassBuilderInfo.MemberOrArgument> filteredSuperArguments = new ArrayList<>(constructor.getSuperArguments());
+                filteredSuperArguments.removeIf(e -> constructor.getArguments().contains(e));
+                if (!filteredSuperArguments.isEmpty()) {
+                    cstr += filteredSuperArguments.stream().map(e -> e.asOneLineString(allImports, false)).collect(Collectors.joining(", "));
                     if (!constructor.getArguments().isEmpty()) {
                         cstr += ", ";
                     }

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/InterfaceCodeGenerator.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/InterfaceCodeGenerator.java
@@ -250,7 +250,7 @@ public class InterfaceCodeGenerator {
         classConstructor.getThrowArguments().add(DBusException.class.getSimpleName());
 
         classConstructor.getSuperArguments().add(new MemberOrArgument("_path", "String", false));
-        classConstructor.getSuperArguments().add(new MemberOrArgument("_interfaceName", "String", false));
+        classConstructor.getSuperArguments().addAll(argsList);
 
         innerClass.getConstructors().add(classConstructor);
 


### PR DESCRIPTION
Interface generation for signals is wrong in some way.
This simple signal

`
<node>
  <interface name="de.Example">
    <signal name="ExampleSignal">
      <arg type="s" name="newState"/>
    </signal>
  </interface>
</node>
`

using `InterfaceCodeGenerator` generates to this interface
`    public interface Example extends DBusInterface {
        public static class ExampleSignal extends DBusSignal {
    
            private final String newState;
    
            public ExampleSignal(String _path, String _interfaceName, String _newState) throws DBusException {
                super(_path, _interfaceName);
                this.newState = _newState;
            }
    
            public String getNewState() {
                return newState;
            }
        }
    }
`

which is wrong. The constructor should be like this instead:
`public ExampleSignal(String _path, String _newState) throws DBusException {
       super(_path, _newState);
       this.newState = _newState;
}`

Explained a bit more in the commit message.