### PR TITLE
Change POM to allow for java-11 builds

### DIFF
--- a/dbus-java-tests/pom.xml
+++ b/dbus-java-tests/pom.xml
@@ -58,7 +58,7 @@
                             <skipAfterFailureCount>1</skipAfterFailureCount>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>${project.groupId}:dbus-java-transport-tcp</classpathDependencyExclude>
-                                <classpathDependencyExclude>${project.groupId}:dbus-java-transport-jnr-unixsocket</classpathDependencyExclude>
+                                <classpathDependencyExclude>${project.groupId}:${dbus-java.transport.exclude}</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                         </configuration>
                     </execution>
@@ -113,12 +113,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.hypfvieh</groupId>
-            <artifactId>dbus-java-transport-native-unixsocket</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
         
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -132,5 +126,25 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jdk-16-available</id>
+            <activation>
+                <jdk>16</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.github.hypfvieh</groupId>
+                    <artifactId>dbus-java-transport-native-unixsocket</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <properties>
+                <dbus-java.transport.exclude>dbus-java-transport-jnr-unixsocket</dbus-java.transport.exclude>
+            </properties>
+        </profile>
+    </profiles>
     
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
         <module>dbus-java-core</module>
         <module>dbus-java-osgi</module>
         <module>dbus-java-utils</module>
-        <module>dbus-java-transport-native-unixsocket</module>
         <module>dbus-java-transport-jnr-unixsocket</module>
         <module>dbus-java-transport-tcp</module>
         <module>dbus-java-tests</module>
@@ -417,6 +416,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jdk-16-available</id>
+            <activation>
+                <jdk>16</jdk>
+            </activation>
+            <modules>
+                <module>dbus-java-transport-native-unixsocket</module>
+            </modules>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
While looking at [PR#7 ](https://github.com/rm5248/dbus-java-nativefd/pull/7) for dbus-java-nativefd, I discovered that dbus-java now requires java 16 to build, although the documentation indicates that only 11 is needed.  This PR should fix it so that it is still possible to build with only java 11.