### PR TITLE
Service exits if exception during authentication.

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/SASL.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/SASL.java
@@ -23,6 +23,7 @@ import java.util.Random;
 
 import org.freedesktop.dbus.connections.transports.AbstractTransport;
 import org.freedesktop.dbus.connections.transports.AbstractUnixTransport;
+import org.freedesktop.dbus.exceptions.AuthenticationException;
 import org.freedesktop.dbus.messages.Message;
 import org.freedesktop.dbus.utils.Hexdump;
 import org.freedesktop.dbus.utils.Util;
@@ -243,7 +244,7 @@ public class SASL {
             return new Command(sb.toString());
         } catch (Exception e) {
             logger.error("Cannot create command.", e);
-            return new Command();
+            throw new AuthenticationException("Failed to authenticate.", e);
         }
     }
 

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/transports/AbstractTransport.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/transports/AbstractTransport.java
@@ -128,9 +128,14 @@ public abstract class AbstractTransport implements Closeable {
      */
     private void authenticate(SocketChannel _sock) throws IOException {
         SASL sasl = new SASL(hasFileDescriptorSupport());
-        if (!sasl.auth(saslMode, saslAuthMode, address.getGuid(), _sock, this)) {
+        try {
+	        if (!sasl.auth(saslMode, saslAuthMode, address.getGuid(), _sock, this)) {
+	            throw new AuthenticationException("Failed to authenticate");
+	        }
+        }
+        catch(IOException e) {
             _sock.close();
-            throw new AuthenticationException("Failed to authenticate");
+        	throw e;
         }
         fileDescriptorSupported = sasl.isFileDescriptorSupported(); // false if server does not support file descriptors
     }


### PR DESCRIPTION
We had a situation where a dbus client would lose connection to the `EmbeddedDBusDaemon` when coming out of hibernate. This happened on OS X, but presumably it's a possibility on other operating systems too. 

For reference, here is the trace we got.

```
18 Jan 2022 07:01:48,123 [EmbeddedDBusDaemon-unix: {path=/tmp/dbus-DJVKKRECWC, guid=1a082ff10254aac4f742ad2bf2c68850, listen=true}] ERROR SASL  - Cannot create command.
java.io.IOException: Invalid Command BEGINl^A^A&^Dn^A^Ao^U/org/freedesktop/DBus^F^As^To
        at org.freedesktop.dbus.connections.SASL$Command.<init>(SASL.java:824)
        at org.freedesktop.dbus.connections.SASL.receive(SASL.java:243)
        at org.freedesktop.dbus.connections.SASL.auth(SASL.java:683)
        at org.freedesktop.dbus.connections.transports.AbstractTransport.authenticate(AbstractTransport.java:131)
        at org.freedesktop.dbus.connections.transports.AbstractTransport.connect(AbstractTransport.java:118)
        at org.freedesktop.dbus.bin.EmbeddedDBusDaemon.startListening(EmbeddedDBusDaemon.java:214)
        at org.freedesktop.dbus.bin.EmbeddedDBusDaemon.startInForeground(EmbeddedDBusDaemon.java:74)
        at java.base/java.lang.Thread.run(Thread.java:833)
18 Jan 2022 07:01:48,170 [DBusConnection] ERROR IncomingMessageThread  - FatalException in connection thread
org.freedesktop.dbus.exceptions.FatalDBusException: Underlying transport returned EOF (1)
        at org.freedesktop.dbus.connections.AbstractConnection.readIncoming(AbstractConnection.java:1154)
        at org.freedesktop.dbus.connections.IncomingMessageThread.run(IncomingMessageThread.java:40)
18 Jan 2022 07:01:48,171 [EmbeddedDBusDaemon-unix: {path=/tmp/dbus-DJVKKRECWC, guid=1a082ff10254aac4f742ad2bf2c68850, listen=true}] ERROR EmbeddedDBusDaemon  - Got uncaught exception
java.lang.NullPointerException: Cannot invoke "org.freedesktop.dbus.connections.SASL$SaslCommand.ordinal()" because the return value of "org.freedesktop.dbus.connections.SASL$Command.getCommand()" is null
        at org.freedesktop.dbus.connections.SASL.auth(SASL.java:684)
        at org.freedesktop.dbus.connections.transports.AbstractTransport.authenticate(AbstractTransport.java:131)
        at org.freedesktop.dbus.connections.transports.AbstractTransport.connect(AbstractTransport.java:118)
        at org.freedesktop.dbus.bin.EmbeddedDBusDaemon.startListening(EmbeddedDBusDaemon.java:214)
        at org.freedesktop.dbus.bin.EmbeddedDBusDaemon.startInForeground(EmbeddedDBusDaemon.java:74)
        at java.base/java.lang.Thread.run(Thread.java:833)
18 Jan 2022 07:01:48,172 [DBusConnection] INFO  Main  - Disconnected from Bus, retrying
```

The SASL chat was somehow getting corrupted, resulting in a failure in the accept loop on the server. 

This PR now throws an exception if the SASL command is not valid. Also `AuthenticationException` is now caught higher up and the connection is also closed. This allows the loop to continue and accept more connections.