### PR TITLE
Revert "Adds a `DBusIgnore` annotation"

### DIFF
--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/signals/SampleObjects.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/signals/SampleObjects.java
@@ -1,0 +1,29 @@
+package org.freedesktop.dbus.test.helper.signals;
+
+import org.freedesktop.dbus.interfaces.DBusInterface;
+
+public abstract class SampleObjects {
+	public interface SampleInterface extends DBusInterface {
+		String getValue();
+	}
+	
+	public static class SampleObject implements SampleInterface {
+		
+		private String value;
+		
+		public SampleObject(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String getValue() {
+			return value;
+		}
+
+		@Override
+		public String getObjectPath() {
+			return null;
+		}
+
+	}
+}


### PR DESCRIPTION
Reverts hypfvieh/dbus-java#164

This change introduces a bug which causes the TestAll#testArrays test to fail.