### PR TITLE
Use `DBusNamingUtil` more widely, value element added to the `DeprecatedOnDBus` and `MethodNoReply` annotations

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/DeprecatedOnDBus.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/DeprecatedOnDBus.java
@@ -4,9 +4,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
-* Indicates that a DBus interface or method is deprecated
-*/
+ * Indicates that a DBus interface or method is deprecated
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @DBusInterfaceName("org.freedesktop.DBus.Deprecated")
 public @interface DeprecatedOnDBus {
+
+    /**
+     * Annotation value, true by default
+     *
+     * @return true when the annotated element deprecated
+     */
+    boolean value() default true;
 }

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/MethodNoReply.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/MethodNoReply.java
@@ -12,4 +12,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @DBusInterfaceName("org.freedesktop.DBus.Method.NoReply")
 public @interface MethodNoReply {
+
+    /**
+     * Annotation value, true by default
+     *
+     * @return true when a method doesn't send a reply
+     */
+    boolean value() default true;
 }


### PR DESCRIPTION
Hello,

This PR includes refactoring and fix in two annotations.

The `DBusNamingUtil` helper methods give us a simpler and safer way to retrieve DBus names.
In this PR, I replaced the code fragments with methods from `DBusNamingUtil`, which reduced the boilerplate code.

The next change affects the two annotations `@DeprecatedOnDBus` and `@MethodNoReply`.
So far when we used first of these annotations on an interface, it produced the following introspection data:

```xml
<node name="/hal/module1">
 <interface name="com.example.HalModule">
  <annotation name="org.freedesktop.DBus.Deprecated" value="" />
  <!-- ... -->
```

Referring to the https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format specification, the value should be *true* or *false*.
So I added the appropriate value element with default value **true** to the annotation, now the introspection data looks like this:
```xml
<node name="/hal/module1">
 <interface name="com.example.HalModule">
  <annotation name="org.freedesktop.DBus.Deprecated" value="true" />
  <!-- ... -->
```

Best regards,
MK