### PR TITLE
Adds a `Closeable` as the return value for all `add*SigHandler()` methods

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
@@ -197,10 +197,11 @@ public abstract class AbstractConnection implements Closeable {
      * @param _handler handler to use
      *
      * @param <T> signal type
+     * @return closeable that removes signal handler
      *
      * @throws DBusException on error
      */
-    protected abstract <T extends DBusSignal> void addSigHandler(DBusMatchRule _rule, DBusSigHandler<T> _handler) throws DBusException;
+    protected abstract <T extends DBusSignal> AutoCloseable addSigHandler(DBusMatchRule _rule, DBusSigHandler<T> _handler) throws DBusException;
 
     /**
      * Remove a generic signal handler with the given {@link DBusMatchRule}.
@@ -220,9 +221,10 @@ public abstract class AbstractConnection implements Closeable {
      *
      * @param _rule rule to add
      * @param _handler handler to use
+     * @return closeable that removes signal handler
      * @throws DBusException on error
      */
-    protected abstract void addGenericSigHandler(DBusMatchRule _rule, DBusSigHandler<DBusSignal> _handler) throws DBusException;
+    protected abstract AutoCloseable addGenericSigHandler(DBusMatchRule _rule, DBusSigHandler<DBusSignal> _handler) throws DBusException;
 
     /**
      * The generated UUID of this machine.
@@ -454,16 +456,17 @@ public abstract class AbstractConnection implements Closeable {
      *            The signal to watch for.
      * @param _handler
      *            The handler to call when a signal is received.
+     * @return closeable that removes signal handler
      * @throws DBusException
      *             If listening for the signal on the bus failed.
      * @throws ClassCastException
      *             If type is not a sub-type of DBusSignal.
      */
-    public <T extends DBusSignal> void addSigHandler(Class<T> _type, DBusSigHandler<T> _handler) throws DBusException {
+    public <T extends DBusSignal> AutoCloseable addSigHandler(Class<T> _type, DBusSigHandler<T> _handler) throws DBusException {
         if (!DBusSignal.class.isAssignableFrom(_type)) {
             throw new ClassCastException("Not A DBus Signal");
         }
-        addSigHandler(new DBusMatchRule(_type), _handler);
+        return addSigHandler(new DBusMatchRule(_type), _handler);
     }
 
     /**
@@ -478,12 +481,13 @@ public abstract class AbstractConnection implements Closeable {
      *            The object from which the signal will be emitted
      * @param _handler
      *            The handler to call when a signal is received.
+     * @return closeable that removes signal handler
      * @throws DBusException
      *             If listening for the signal on the bus failed.
      * @throws ClassCastException
      *             If type is not a sub-type of DBusSignal.
      */
-    public <T extends DBusSignal> void addSigHandler(Class<T> _type, DBusInterface _object, DBusSigHandler<T> _handler)
+    public <T extends DBusSignal> AutoCloseable addSigHandler(Class<T> _type, DBusInterface _object, DBusSigHandler<T> _handler)
             throws DBusException {
         if (!DBusSignal.class.isAssignableFrom(_type)) {
             throw new ClassCastException("Not A DBus Signal");
@@ -496,7 +500,7 @@ public abstract class AbstractConnection implements Closeable {
         if (objectpath.length() > MAX_NAME_LENGTH || !OBJECT_REGEX_PATTERN.matcher(objectpath).matches()) {
             throw new DBusException("Invalid object path: " + objectpath);
         }
-        addSigHandler(new DBusMatchRule(_type, null, objectpath), _handler);
+        return addSigHandler(new DBusMatchRule(_type, null, objectpath), _handler);
     }
 
     protected <T extends DBusSignal> void addSigHandlerWithoutMatch(Class<? extends DBusSignal> _signal, DBusSigHandler<T> _handler) throws DBusException {

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
@@ -749,6 +749,7 @@ public final class DBusConnection extends AbstractConnection {
      * @param _source
      *            The process which will send the signal. This <b>MUST</b> be a unique bus name and not a well known
      *            name.
+     * @return closeable that removes signal handler
      * @param _handler
      *            The handler to call when a signal is received.
      * @throws DBusException
@@ -756,10 +757,17 @@ public final class DBusConnection extends AbstractConnection {
      * @throws ClassCastException
      *             If type is not a sub-type of DBusSignal.
      */
-    public <T extends DBusSignal> void addSigHandler(Class<T> _type, String _source, DBusSigHandler<T> _handler)
+    public <T extends DBusSignal> AutoCloseable addSigHandler(Class<T> _type, String _source, DBusSigHandler<T> _handler)
             throws DBusException {
         validateSignal(_type, _source);
         addSigHandler(new DBusMatchRule(_type, _source, null), (DBusSigHandler<? extends DBusSignal>) _handler);
+        return new AutoCloseable() {
+			
+			@Override
+			public void close() throws DBusException {
+				removeSigHandler(_type, _source, _handler);
+			}
+		};
     }
 
     /**
@@ -777,12 +785,13 @@ public final class DBusConnection extends AbstractConnection {
      *            The object from which the signal will be emitted
      * @param _handler
      *            The handler to call when a signal is received.
+     * @return closeable that removes signal handler
      * @throws DBusException
      *             If listening for the signal on the bus failed.
      * @throws ClassCastException
      *             If type is not a sub-type of DBusSignal.
      */
-    public <T extends DBusSignal> void addSigHandler(Class<T> _type, String _source, DBusInterface _object,
+    public <T extends DBusSignal> AutoCloseable addSigHandler(Class<T> _type, String _source, DBusInterface _object,
             DBusSigHandler<T> _handler) throws DBusException {
         validateSignal(_type, _source);
 
@@ -791,6 +800,12 @@ public final class DBusConnection extends AbstractConnection {
             throw new DBusException("Invalid object path: " + objectpath);
         }
         addSigHandler(new DBusMatchRule(_type, _source, objectpath), (DBusSigHandler<? extends DBusSignal>) _handler);
+        return new AutoCloseable() {
+			@Override
+			public void close() throws DBusException {
+				removeSigHandler(_type, _source, _object, _handler);
+			}
+		};
     }
 
     /**
@@ -818,7 +833,7 @@ public final class DBusConnection extends AbstractConnection {
      * {@inheritDoc}
      */
     @Override
-    public <T extends DBusSignal> void addSigHandler(DBusMatchRule _rule, DBusSigHandler<T> _handler)
+    public <T extends DBusSignal> AutoCloseable addSigHandler(DBusMatchRule _rule, DBusSigHandler<T> _handler)
             throws DBusException {
 
         Objects.requireNonNull(_rule, "Match rule cannot be null");
@@ -847,6 +862,12 @@ public final class DBusConnection extends AbstractConnection {
                 throw new DBusException("Cannot add match rule.", dbee);
             }
         }
+        return new AutoCloseable() {
+			@Override
+			public void close() throws DBusException {
+				removeSigHandler(_rule, _handler);
+			}
+		};
     }
 
     /**
@@ -947,7 +968,7 @@ public final class DBusConnection extends AbstractConnection {
     }
 
     @Override
-    public void addGenericSigHandler(DBusMatchRule _rule, DBusSigHandler<DBusSignal> _handler) throws DBusException {
+    public AutoCloseable addGenericSigHandler(DBusMatchRule _rule, DBusSigHandler<DBusSignal> _handler) throws DBusException {
         SignalTuple key = new SignalTuple(_rule.getInterface(), _rule.getMember(), _rule.getObject(), _rule.getSource());
 
         AtomicBoolean addMatch = new AtomicBoolean(false); // flag to perform action if this is a new signal key
@@ -970,6 +991,12 @@ public final class DBusConnection extends AbstractConnection {
                 throw new DBusException(dbee.getMessage());
             }
         }
+        return new AutoCloseable() {
+			@Override
+			public void close() throws DBusException {
+				removeGenericSigHandler(_rule, _handler);
+			}
+		};
     }
 
     private class SigHandler implements DBusSigHandler<DBusSignal> {

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
@@ -255,7 +255,7 @@ public class DirectConnection extends AbstractConnection {
     }
 
     @Override
-    protected <T extends DBusSignal> void addSigHandler(DBusMatchRule _rule, DBusSigHandler<T> _handler) throws DBusException {
+    protected <T extends DBusSignal> AutoCloseable addSigHandler(DBusMatchRule _rule, DBusSigHandler<T> _handler) throws DBusException {
         SignalTuple key = new SignalTuple(_rule.getInterface(), _rule.getMember(), _rule.getObject(), _rule.getSource());
 
         Queue<DBusSigHandler<? extends DBusSignal>> v =
@@ -265,6 +265,12 @@ public class DirectConnection extends AbstractConnection {
                 });
 
         v.add(_handler);
+        return new AutoCloseable() {
+			@Override
+			public void close() throws Exception {
+				removeSigHandler(_rule, _handler);
+			}
+		};
     }
 
     @Override
@@ -280,7 +286,7 @@ public class DirectConnection extends AbstractConnection {
     }
 
     @Override
-    protected void addGenericSigHandler(DBusMatchRule _rule, DBusSigHandler<DBusSignal> _handler) throws DBusException {
+    protected AutoCloseable addGenericSigHandler(DBusMatchRule _rule, DBusSigHandler<DBusSignal> _handler) throws DBusException {
         SignalTuple key = new SignalTuple(_rule.getInterface(), _rule.getMember(), _rule.getObject(), _rule.getSource());
         Queue<DBusSigHandler<DBusSignal>> v =
                 getGenericHandledSignals().computeIfAbsent(key, val -> {
@@ -289,6 +295,12 @@ public class DirectConnection extends AbstractConnection {
                 });
 
         v.add(_handler);
+        return new AutoCloseable() {
+			@Override
+			public void close() throws Exception {
+				removeGenericSigHandler(_rule, _handler);
+			}
+		};
     }
 
     @Override


### PR DESCRIPTION
This may be called to remove same signal handler.

See https://github.com/hypfvieh/dbus-java/issues/175