### PR TITLE
Allow SASL UID to be provided via the `TransportBuilder`

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/SASL.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/SASL.java
@@ -26,6 +26,7 @@ import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.Random;
 
 import org.freedesktop.dbus.connections.transports.AbstractTransport;
@@ -422,17 +423,18 @@ public class SASL {
      * @param _mode mode
      * @param _types types
      * @param _guid guid
+     * @param _saslUid SASL UID
      * @param _sock socket channel
      * @param _transport transport
      *
      * @return true if the auth was successful and false if it failed.
      * @throws IOException on failure
      */
-    public boolean auth(SaslMode _mode, int _types, String _guid, SocketChannel _sock, AbstractTransport _transport) throws IOException {
+    public boolean auth(SaslMode _mode, int _types, String _guid, OptionalLong _saslUid, SocketChannel _sock, AbstractTransport _transport) throws IOException {
         String luid = null;
         String kernelUid = null;
 
-        long uid = getUserId();
+        long uid = _saslUid.orElse(getUserId());
         luid = stupidlyEncode("" + uid);
 
         SASL.Command c;

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/config/TransportConfig.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/config/TransportConfig.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -29,6 +30,7 @@ public final class TransportConfig {
     private int                         timeout          = 10000;
     private boolean                     autoConnect      = true;
     private SaslAuthMode                authMode         = null;
+    private OptionalLong                saslUid          = OptionalLong.empty();
 
     /** user to set on socket file if this is a server transport (null to do nothing). */
     private String                      fileOwner;
@@ -94,7 +96,15 @@ public final class TransportConfig {
         timeout = _timeout;
     }
 
-    public SaslAuthMode getAuthMode() {
+    public OptionalLong getSaslUid() {
+		return saslUid;
+	}
+
+	public void setSaslUid(OptionalLong _saslUid) {
+		this.saslUid = _saslUid;
+	}
+
+	public SaslAuthMode getAuthMode() {
         return authMode;
     }
 

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/config/TransportConfigBuilder.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/config/TransportConfigBuilder.java
@@ -2,6 +2,7 @@ package org.freedesktop.dbus.connections.config;
 
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -139,6 +140,20 @@ public class TransportConfigBuilder<X extends TransportConfigBuilder<?, R>, R> {
         if (_timeout >= 0) {
             config.setTimeout(_timeout);
         }
+        return self();
+    }
+
+    /**
+     * Set to UID to present during SASL authentication.
+     * <p>
+     * Default is the user of the running JVM process on Unix-like operating systems. On Windows, the default is zero.<br><br>
+     *
+     * @param _saslUid UID to set, if -1 is given default is used
+     *
+     * @return this
+     */
+    public X withSaslUid(long _saslUid) {
+        config.setSaslUid(_saslUid == -1 ? OptionalLong.empty() : OptionalLong.of(_saslUid));
         return self();
     }
 

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/transports/AbstractTransport.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/transports/AbstractTransport.java
@@ -3,6 +3,7 @@ package org.freedesktop.dbus.connections.transports;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.SocketChannel;
+import java.util.OptionalLong;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
@@ -34,6 +35,7 @@ public abstract class AbstractTransport implements Closeable {
     private final BusAddress                     address;
 
     private SASL.SaslMode                        saslMode;
+    private OptionalLong                         saslUid;
 
     private int                                  saslAuthMode;
     private IMessageReader                       inputReader;
@@ -155,7 +157,7 @@ public abstract class AbstractTransport implements Closeable {
     private void authenticate(SocketChannel _sock) throws IOException {
         SASL sasl = new SASL(hasFileDescriptorSupport());
         try {
-            if (!sasl.auth(saslMode, saslAuthMode, address.getGuid(), _sock, this)) {
+            if (!sasl.auth(saslMode, saslAuthMode, address.getGuid(), saslUid, _sock, this)) {
                 throw new AuthenticationException("Failed to authenticate");
             }
         } catch (IOException e) {
@@ -200,7 +202,15 @@ public abstract class AbstractTransport implements Closeable {
 
     }
 
-    protected int getSaslAuthMode() {
+    protected OptionalLong getSaslUid() {
+		return saslUid;
+	}
+
+	protected void setSaslUid(OptionalLong saslUid) {
+		this.saslUid = saslUid;
+	}
+
+	protected int getSaslAuthMode() {
         return saslAuthMode;
     }
 

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/transports/TransportBuilder.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/transports/TransportBuilder.java
@@ -324,6 +324,7 @@ public class TransportBuilder {
             ((IFileBasedBusAddress) myBusAddress).updatePermissions(config.getFileOwner(), config.getFileGroup(), config.getFileUnixPermissions());
         }
 
+        transport.setSaslUid(config.getSaslUid());
         transport.setPreConnectCallback(config.getPreConnectCallback());
 
         if (config.isAutoConnect()) {


### PR DESCRIPTION
.. instead of being detected.

There are a couple of reasons for this PR.

1. I have an SSH transport. If I am using SASL, and if I am connecting from a machine where the local user UID differs from the authenticated user on the remote machine, the DBus connection will not be allowed. We must pretend that our UID is that of the remote user. I do not see this as security issue, the user is already authenticated by SSH, and the broker is validating that the connection is coming from the remote user.

2. The use of `UnixSystem` breaks when attempting to compile to native code with GraalVM (actually, it fails to link). I believe this is a bug in Graal, but nevertheless `UnixSystem` is not part of the official API and is platform dependent. This is the sole reason for depending on the `jdk.security.auth` module.

Usage :-

`builder.transportConfig().withSaslUid(1000);`