### PR TITLE
Add signal handler deregistration example

### DIFF
--- a/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/signal/PropertiesChangedSignal.java
+++ b/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/signal/PropertiesChangedSignal.java
@@ -9,25 +9,27 @@ import org.freedesktop.dbus.handlers.AbstractPropertiesChangedHandler;
 import org.freedesktop.dbus.interfaces.Properties.PropertiesChanged;
 
 /**
- * Sample on how to register a callback for a signal.
- * <p>
- * In this case a global {@link PropertiesChanged} handler is installed.
- * It will be queried for every properties changed event on the bus.
+ * This example code demonstrates how to register a callback for a signal.
+ * A global {@link PropertiesChanged} handler is installed, which is queried
+ * for every properties changed event on the bus.
  *
  * @author hypfvieh
  */
 public class PropertiesChangedSignal {
 
-    public static void main(String[] _args) throws DBusException, InterruptedException, IOException {
-        // open connection to SYSTEM Bus
+    public static void main(String[] _args) throws Exception {
+        // Open connection to the system bus.
         try (DBusConnection connection = DBusConnectionBuilder.forSystemBus().build()) {
-            // add our signal handler
-            connection.addSigHandler(PropertiesChanged.class, new PropChangedHandler());
+            // Add a signal handler.
+            final var token = connection.addSigHandler(PropertiesChanged.class, new PropChangedHandler());
 
-            // just do some sleep so you can see the events on stdout (you would probably do something else here)
+            // Pause to see events written to stdout (your code would differ).
             System.out.println("sleeping");
             Thread.sleep(60000L);
             System.out.println("shutting down");
+
+            // Remove the signal handler.
+            token.close();
         }
     }
 
@@ -35,11 +37,9 @@ public class PropertiesChangedSignal {
      * This handler will be called for every property change signal.
      */
     public static class PropChangedHandler extends AbstractPropertiesChangedHandler {
-
         @Override
         public void handle(PropertiesChanged _s) {
             System.out.println("changed: " + _s.getPropertiesChanged());
         }
-
     }
 }


### PR DESCRIPTION
Updates an example to show how to unregister a signal handler.