### PR TITLE
Add Variant of Map example

### DIFF
--- a/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/networkmanager/NetworkManagerExample3.java
+++ b/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/networkmanager/NetworkManagerExample3.java
@@ -1,0 +1,98 @@
+package com.github.hypfvieh.dbus.examples.networkmanager;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+import org.freedesktop.networkmanager.Settings;
+import org.freedesktop.networkmanager.settings.Connection;
+
+public class NetworkManagerExample3 {
+    public static void main( String[] args ) {
+        if(args.length < 2) {
+            System.out.println("Usage: <uuid> <auto|static> [address prefix gateway]");
+            System.exit(1);
+        }
+
+        String method = args[1];
+        if( method == "static" && args.length < 4) {
+            System.out.println("Usage: <uuid> <static> address prefix [gateway]");
+            System.exit(1);
+        }
+
+        // Convert method to NM method
+        if(method.equals("static")) {
+            method = "manual";
+        }
+
+        try (DBusConnection dbusConn = DBusConnectionBuilder.forSystemBus().build()) {
+
+            Settings settings = dbusConn.getRemoteObject("org.freedesktop.NetworkManager",
+                    "/org/freedesktop/NetworkManager/Settings", Settings.class);
+
+            for (DBusInterface connectionIf : settings.ListConnections()) {
+                Connection connection = dbusConn.getRemoteObject("org.freedesktop.NetworkManager",
+                        connectionIf.getObjectPath().toString(), Connection.class);
+
+                Map<String, Map<String, Variant<?>>> connectionSettings = connection.GetSettings();
+
+                // Look for the requested connection UUID
+                if(!connectionSettings.get("connection").get("uuid").getValue().toString().equals(args[0])) {
+                    continue;
+                }
+
+                // Deep copy
+                Map<String, Variant<?>> connectionMap = new HashMap<>();
+                for (String key : connectionSettings.get("connection").keySet()) {
+                    connectionMap.put(key, connectionSettings.get("connection").get(key));
+                }
+                Map<String, Variant<?>> ipv4Map = new HashMap<>();
+                for (String key : connectionSettings.get("ipv4").keySet()) {
+                    ipv4Map.put(key, connectionSettings.get("ipv4").get(key));
+                }
+
+                // Clear existing address info
+                ipv4Map.remove("addresses");
+                ipv4Map.remove("address-data");
+                ipv4Map.remove("gateway");
+
+                // Set the method and change properties
+                ipv4Map.put("method", new Variant<String>(method));
+
+                if(method.equals("manual")) {
+                    // Add the static IP address, prefix and (optional) gateway
+                    Map<String, Variant<?>> address = new HashMap<>();
+                    address.put("address", new Variant<String>(args[2]));
+                    address.put("prefix", new Variant<UInt32>(new UInt32(args[3])));
+
+                    List<Map<String, Variant<?>>> addressData = Arrays.asList(address);
+                    ipv4Map.put("address-data", new Variant<>(addressData, "aa{sv}"));
+
+                    if(args.length == 5) {
+                        ipv4Map.put("gateway", new Variant<String>(args[4]));
+                    }
+                }
+
+                // Build output data
+                Map<String, Map<String, Variant<?>>> newConnectionSettings = new HashMap<>();
+                newConnectionSettings.put("ipv4", ipv4Map);
+                newConnectionSettings.put("connection", connectionMap);
+
+                // Update & save connection settings
+                connection.Update(newConnectionSettings);
+                connection.Save();
+            }
+
+        } catch (IOException | DBusException _ex) {
+            _ex.printStackTrace();
+        }
+    }
+}

--- a/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/networkmanager/NetworkManagerExample3.java
+++ b/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/networkmanager/NetworkManagerExample3.java
@@ -15,6 +15,15 @@ import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.networkmanager.Settings;
 import org.freedesktop.networkmanager.settings.Connection;
 
+/**
+ * Sample code which updates a connection's IPv4 method with the Update() method.
+ *
+ * This uses the new NM 1.0 setting properties. Configuration settings are
+ * described at https://networkmanager.dev/docs/api/latest/ref-settings.html
+ *
+ * @author mattdibi
+ *
+ */
 public class NetworkManagerExample3 {
     public static void main( String[] args ) {
         if(args.length < 2) {

--- a/dbus-java-examples/src/main/java/org/freedesktop/networkmanager/Settings.java
+++ b/dbus-java-examples/src/main/java/org/freedesktop/networkmanager/Settings.java
@@ -1,0 +1,74 @@
+package org.freedesktop.networkmanager;
+
+import java.util.List;
+import java.util.Map;
+
+import org.freedesktop.Pair;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.interfaces.Properties;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+@DBusInterfaceName("org.freedesktop.NetworkManager.Settings")
+public interface Settings extends DBusInterface, Properties {
+
+    public List<DBusInterface> ListConnections();
+
+    public DBusInterface GetConnectionByUuid(String uuid);
+
+    public DBusInterface AddConnection(Map<String, Map<String, Variant<?>>> connection);
+
+    public DBusInterface AddConnectionUnsaved(Map<String, Map<String, Variant<?>>> connection);
+
+    public Pair<DBusInterface, Map<String, Variant<?>>> AddConnection2(Map<String, Map<String, Variant<?>>> settings,
+            UInt32 flags, Map<String, Variant<?>> args);
+
+    public Pair<Boolean, List<String>> LoadConnections(List<String> filenames);
+
+    public boolean ReloadConnections();
+
+    public void SaveHostname(String hostname);
+
+    public static class NewConnection extends DBusSignal {
+
+        /** Object path of the new connection. */
+        private final DBusInterface connection;
+
+        NewConnection(String _path, DBusInterface _connection) throws DBusException {
+            super(_path, _connection);
+            this.connection = _connection;
+        }
+
+        public DBusInterface getConnection() {
+            return connection;
+        }
+    }
+
+    public static class ConnectionRemoved extends DBusSignal {
+
+        /** Object path of the removed connection. */
+        private final DBusInterface connection;
+
+        ConnectionRemoved(String _path, DBusInterface _connection) throws DBusException {
+            super(_path, _connection);
+            this.connection = _connection;
+        }
+
+        public DBusInterface getConnection() {
+            return connection;
+        }
+    }
+
+    class PropertyNames {
+
+        /** List of object paths of available network connection profiles. */
+        public static final String Connections = "Connections";
+        /** The machine hostname stored in persistent configuration. */
+        public static final String Hostname = "Hostname";
+        /** If true, adding and modifying connections is supported. */
+        public static final String CanModify = "CanModify";
+    }
+}

--- a/dbus-java-examples/src/main/java/org/freedesktop/networkmanager/settings/Connection.java
+++ b/dbus-java-examples/src/main/java/org/freedesktop/networkmanager/settings/Connection.java
@@ -1,0 +1,52 @@
+package org.freedesktop.networkmanager.settings;
+
+import java.util.Map;
+
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+@DBusInterfaceName("org.freedesktop.NetworkManager.Settings.Connection")
+public interface Connection extends DBusInterface {
+
+    void Update(Map<String, Map<String, Variant<?>>> properties);
+
+    void UpdateUnsaved(Map<String, Map<String, Variant<?>>> properties);
+
+    void Delete();
+
+    Map<String, Map<String, Variant<?>>> GetSettings();
+
+    Map<String, Map<String, Variant<?>>> GetSecrets(String settingName);
+
+    void ClearSecrets();
+
+    void Save();
+
+    Map<String, Variant<?>> Update2(Map<String, Map<String, Variant<?>>> settings, UInt32 flags,
+            Map<String, Variant<?>> args);
+
+    public static class Updated extends DBusSignal {
+
+        public Updated(String path) throws DBusException {
+            super(path);
+        }
+    }
+
+    public static class Removed extends DBusSignal {
+
+        public Removed(String path) throws DBusException {
+            super(path);
+        }
+    }
+
+    class PropertyNames {
+
+        public static final String Unsaved = "Unsaved";
+        public static final String Flags = "Flags";
+        public static final String Filename = "Filename";
+    }
+}


### PR DESCRIPTION
As requested in #74 I added a new example showing the use [of the `signature` for the `Variant` constructor](https://github.com/hypfvieh/dbus-java/blob/12db377f5812ca173bd52cbcefe4378c47b4dec6/dbus-java-core/src/main/java/org/freedesktop/dbus/types/Variant.java#L78).

The example is a Java implementation of the example provided in the official NetworkManager repository found [here](https://github.com/NetworkManager/NetworkManager/blob/main/examples/python/dbus/update-ip4-method.py).