### PR TITLE
 BUGFIX: add the interface type if given when creating the proxy

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
@@ -327,7 +327,7 @@ public final class DBusConnection extends AbstractConnection {
                 ifcs.add(DBusInterface.class);
             }
 
-            RemoteObject ro = new RemoteObject(_source, _path, null, false);
+            RemoteObject ro = new RemoteObject(_source, _path, _type, false);
             DBusInterface newi = (DBusInterface) Proxy.newProxyInstance(ifcs.get(0).getClassLoader(),
                     ifcs.toArray(Class[]::new), new RemoteInvocationHandler(this, ro));
             getImportedObjects().put(newi, ro);

--- a/dbus-java-tests/src/test/java/org/freedesktop/DBus.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/DBus.java
@@ -1,0 +1,13 @@
+package org.freedesktop;
+
+import org.freedesktop.dbus.interfaces.DBusInterface;
+
+public interface DBus extends DBusInterface {
+	public interface Peer extends DBusInterface {
+
+		public String GetMachineId();
+
+		public void Ping();
+
+	}
+}

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/InterfaceCreationTest.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/InterfaceCreationTest.java
@@ -1,0 +1,70 @@
+// The package must be "both" org.freedesktop.dbus.connections.impl and org.freedesktop.dbus in order
+// for the test to be able to access the requisite methods and fields... obviously this is an issue...
+package org.freedesktop.dbus;
+
+import java.lang.reflect.Proxy;
+
+import org.freedesktop.DBus;
+import org.freedesktop.dbus.bin.EmbeddedDBusDaemon;
+import org.freedesktop.dbus.connections.BusAddress;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
+import org.freedesktop.dbus.connections.transports.TransportBuilder;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.test.AbstractBaseTest;
+import org.junit.jupiter.api.Assertions;
+
+public class InterfaceCreationTest extends AbstractBaseTest {
+
+	// @Test
+	public void testCorrectInterfaceCreation() throws Exception {
+		String protocolType = TransportBuilder.getRegisteredBusTypes().get(0);
+		BusAddress busAddress = TransportBuilder.createWithDynamicSession(protocolType).configure().build()
+			.getBusAddress();
+
+		BusAddress listenBusAddress = BusAddress.of(busAddress).getListenerAddress();
+
+		try (EmbeddedDBusDaemon daemon = new EmbeddedDBusDaemon(listenBusAddress)) {
+			daemon.startInBackground();
+			this.logger.debug("Started embedded bus on address {}", listenBusAddress);
+
+			waitForDaemon(daemon);
+
+			// connect to started daemon process
+			this.logger.info("Connecting to embedded DBus {}", busAddress);
+
+			final String source = "org.freedesktop.DBus";
+			final String path = "/org/freedesktop/DBus";
+
+			try (DBusConnection connection = DBusConnectionBuilder.forAddress(busAddress).build()) {
+				DBusInterface dbi = null;
+				RemoteInvocationHandler rih = null;
+				RemoteObject ro = null;
+				Class<? extends DBusInterface> type = DBus.Peer.class;
+
+				dbi = connection.getExportedObject(source, path, null);
+				Assertions.assertNotNull(dbi);
+
+				rih = RemoteInvocationHandler.class.cast(Proxy.getInvocationHandler(dbi));
+				Assertions.assertNotNull(rih);
+
+				ro = rih.remote;
+
+				Assertions.assertNull(ro.getInterface());
+
+				dbi = connection.getExportedObject(source, path, type);
+				Assertions.assertNotNull(dbi);
+				Assertions.assertTrue(type.isInstance(dbi));
+
+				rih = RemoteInvocationHandler.class.cast(Proxy.getInvocationHandler(dbi));
+				Assertions.assertNotNull(rih);
+
+				ro = rih.remote;
+
+				Assertions.assertNotNull(ro.getInterface());
+				Assertions.assertSame(type, ro.getInterface());
+			}
+		}
+	}
+
+}

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/InterfaceCreationTest.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/InterfaceCreationTest.java
@@ -13,10 +13,11 @@ import org.freedesktop.dbus.connections.transports.TransportBuilder;
 import org.freedesktop.dbus.interfaces.DBusInterface;
 import org.freedesktop.dbus.test.AbstractBaseTest;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class InterfaceCreationTest extends AbstractBaseTest {
 
-	// @Test
+	@Test
 	public void testCorrectInterfaceCreation() throws Exception {
 		String protocolType = TransportBuilder.getRegisteredBusTypes().get(0);
 		BusAddress busAddress = TransportBuilder.createWithDynamicSession(protocolType).configure().build()


### PR DESCRIPTION
The interface type value "_type" is already null if not given as a parameter. But if given, it's being ignored while constructing the RemoteObject reference that will eventually be proxied. This leads to method invocations failing with "strange" errors (inapplicable instances of "access denied", for instance).

This correction caused the methods to at least be invoked correctly, and a test that verifies that this doesn't happen again by accident.