### PR TITLE
Modified the POM files to be more CI/CD friendly

### DIFF
--- a/dbus-java-bom/pom.xml
+++ b/dbus-java-bom/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.github.hypfvieh</groupId>
         <artifactId>dbus-java-parent</artifactId>
-        <version>4.2.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/dbus-java-core/pom.xml
+++ b/dbus-java-core/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.github.hypfvieh</groupId>
         <artifactId>dbus-java-parent</artifactId>
-        <version>4.2.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/dbus-java-examples/pom.xml
+++ b/dbus-java-examples/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.github.hypfvieh</groupId>
         <artifactId>dbus-java-parent</artifactId>
-        <version>4.2.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/dbus-java-osgi/pom.xml
+++ b/dbus-java-osgi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>com.github.hypfvieh</groupId>
         <artifactId>dbus-java-parent</artifactId>
-        <version>4.2.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/dbus-java-tests/pom.xml
+++ b/dbus-java-tests/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.github.hypfvieh</groupId>
         <artifactId>dbus-java-parent</artifactId>
-        <version>4.2.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/dbus-java-transport-jnr-unixsocket/pom.xml
+++ b/dbus-java-transport-jnr-unixsocket/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.github.hypfvieh</groupId>
         <artifactId>dbus-java-parent</artifactId>
-        <version>4.2.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/dbus-java-transport-native-unixsocket/pom.xml
+++ b/dbus-java-transport-native-unixsocket/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.github.hypfvieh</groupId>
         <artifactId>dbus-java-parent</artifactId>
-        <version>4.2.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/dbus-java-transport-tcp/pom.xml
+++ b/dbus-java-transport-tcp/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.github.hypfvieh</groupId>
         <artifactId>dbus-java-parent</artifactId>
-        <version>4.2.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/dbus-java-utils/pom.xml
+++ b/dbus-java-utils/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.github.hypfvieh</groupId>
         <artifactId>dbus-java-parent</artifactId>
-        <version>4.2.2-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.hypfvieh</groupId>
     <artifactId>dbus-java-parent</artifactId>
-    <version>4.2.2-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <name>${project.artifactId}</name>
     <url>https://github.com/hypfvieh/dbus-java</url>
@@ -14,6 +14,7 @@
     <description>DBus-Java library module parent</description>
 
     <properties>
+        <revision>4.2.2-SNAPSHOT</revision>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten.process-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <pluginManagement>


### PR DESCRIPTION
In the new CI/CD world, it's easier to set a version for a specific build by just setting -Drevision=... and invoking the build. This significantly facilitates the whole versioning paradigm since the version is now only stored in a single, centralized place.

Now, whenever a version bump is needed, only the "master" value in the root pom.xml needs to be updated. This should only affect the build process.

See https://maven.apache.org/maven-ci-friendly.html for more details on ${revision}, ${changelist}, and ${sha1} and their usefulness in the modern, CI/CD world.