### PR TITLE
Makes it possible to map DBUS properties directly to setter / getters

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/DBusProperty.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/DBusProperty.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @see org.freedesktop.dbus.interfaces.DBusInterface
  * @see org.freedesktop.dbus.TypeRef
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(DBusProperties.class)
 public @interface DBusProperty {
@@ -40,7 +40,7 @@ public @interface DBusProperty {
      *
      * @return name
      */
-    String name();
+    String name() default "";
 
     /**
      * type of the property, in case of complex types please create custom interface that extends {@link org.freedesktop.dbus.TypeRef}

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/DBusNamingUtil.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/DBusNamingUtil.java
@@ -2,6 +2,7 @@ package org.freedesktop.dbus.utils;
 
 import org.freedesktop.dbus.annotations.DBusInterfaceName;
 import org.freedesktop.dbus.annotations.DBusMemberName;
+import org.freedesktop.dbus.annotations.DBusProperty;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -47,6 +48,33 @@ public final class DBusNamingUtil {
             return _method.getAnnotation(DBusMemberName.class).value();
         }
         return _method.getName();
+    }
+
+    /**
+     * Get a property name for a method (annotated with {@link DBusProperty}. These
+     * would typically be setter / getter type methods. If {@link DBusProperty#name()} is
+     * provided, that will take precedence.
+     *
+     * @param _method input method
+     * @return property name
+     * @see DBusMemberName
+     */
+    public static String getPropertyName(Method _method) {
+        Objects.requireNonNull(_method, "method must not be null");
+
+        if (_method.isAnnotationPresent(DBusProperty.class)) {
+            String defName = _method.getAnnotation(DBusProperty.class).name();
+            if (!"".equals(defName)) {
+                return defName;
+            }
+        }
+        String name = _method.getName();
+        if ((name.startsWith("get") && !"get".equals(name)) || (name.startsWith("set") && !"set".equals(name))) {
+            name = name.substring(3);
+        } else if (name.startsWith("is") && !"is".equals(name)) {
+            name = name.substring(2);
+        }
+        return name;
     }
 
     /**

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/PropertyRef.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/PropertyRef.java
@@ -1,0 +1,98 @@
+package org.freedesktop.dbus.utils;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+// CHECKSTYLE:OFF
+/* TODO Impossible to correct. Whichever way around these imports are, checkstyle complains */
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.types.Variant;
+import org.freedesktop.dbus.annotations.DBusProperty;
+// CHECKSTYLE:ON
+
+/**
+ * Contains the same information as a {@link DBusProperty}, but as a POJO. Use
+ * internally when dealing with properties that are derived methods annotated
+ * with said annotation.
+ */
+public final  class PropertyRef {
+
+    private final String name;
+    private final Class<?> type;
+    private final DBusProperty.Access access;
+
+    public PropertyRef(String _name, Class<?> _type, Access _access) {
+        super();
+        this.name = _name;
+        this.type = _type;
+        this.access = _access;
+    }
+
+    public PropertyRef(DBusProperty _property) {
+        this(_property.name(), _property.type(), _property.access());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(access, name);
+    }
+
+    @Override
+    public boolean equals(Object _obj) {
+        if (this == _obj) {
+            return true;
+        }
+        if (_obj == null) {
+            return false;
+        }
+        if (getClass() != _obj.getClass()) {
+            return false;
+        }
+        PropertyRef other = (PropertyRef) _obj;
+        return access == other.access && Objects.equals(name, other.name);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Class<?> getType() {
+        return type;
+    }
+
+    public DBusProperty.Access getAccess() {
+        return access;
+    }
+
+    public static Access accessForMethod(Method _method) {
+        var annotation = _method.getAnnotation(DBusProperty.class);
+        var access = _method.getName().startsWith("set") ? Access.WRITE : Access.READ;
+        if (annotation.access().equals(Access.READ) || annotation.access().equals(Access.WRITE)) {
+            access = annotation.access();
+        }
+        return access;
+    }
+
+    public static Class<?> typeForMethod(Method _method) {
+        var annotation = _method.getAnnotation(DBusProperty.class);
+        var type = annotation.type();
+        if (type == null || type.equals(Variant.class)) {
+            if (accessForMethod(_method) == Access.READ) {
+                return _method.getReturnType();
+            } else {
+                return _method.getParameterTypes()[0];
+            }
+        }
+        return type;
+    }
+
+    public static void checkMethod(Method _method) {
+        var access = accessForMethod(_method);
+        if (access == Access.READ && (_method.getParameterCount() > 0 || _method.getReturnType().equals(void.class))) {
+            throw new IllegalArgumentException("READ properties must have zero parameters, and not return void.");
+        }
+        if (access == Access.WRITE && (_method.getParameterCount() != 1 || !_method.getReturnType().equals(void.class))) {
+            throw new IllegalArgumentException("WRITE properties must have exaclty 1 parameter, and return void.");
+        }
+    }
+}

--- a/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/properties/ExportObjectWithProperties.java
+++ b/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/properties/ExportObjectWithProperties.java
@@ -1,0 +1,55 @@
+package com.github.hypfvieh.dbus.examples.properties;
+
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
+import org.freedesktop.dbus.interfaces.Properties;
+
+/**
+ * Sample which demonstrates on how to use an alternative mechanism to
+ * provide DBus properties directly using getter and setter methods.
+ * This means you do not have to implement support yourself by
+ * implementing {@link Properties#Get(String, String)} etc.
+ *
+ * @author brettsmith / hypfvieh
+ *
+ * @since 4.3.1 - 2023-09-28
+ */
+public final class ExportObjectWithProperties {
+
+    private ExportObjectWithProperties() {}
+
+    public static void main(String[] _args) throws Exception {
+        try (var conn = DBusConnectionBuilder.forSessionBus().withShared(false).build()) {
+            // create object
+            var obj = new ObjectWithProperties();
+            obj.setMyProperty("My property value");
+
+            conn.requestBusName("com.acme");
+
+            // export to bus
+            conn.exportObject(obj);
+
+            try (DBusConnection innerConn = DBusConnectionBuilder.forSessionBus().withShared(false).build()) {
+                // get the exported object
+                InterfaceWithProperties myObject = innerConn.getRemoteObject("com.acme", "/com/acme/ObjectWithProperties", InterfaceWithProperties.class);
+
+                // Print hello from 'parent' object
+                System.out.println("> " + myObject.sayHello());
+
+                // Print value of property from object via its getter
+                System.out.println("> " + myObject.getMyProperty());
+
+                // Change values of property on object via their setters
+                myObject.setMyProperty("A new value!");
+                myObject.setMyOtherProperty(true);
+                myObject.setMyAltProperty(987);
+
+            }
+
+            // Prove value of property on original object
+            System.out.println("This should say 'A new value!': " + obj.getMyProperty());
+            System.out.println("This should say 'true': " + obj.isMyOtherProperty());
+            System.out.println("This should say '987': " + obj.getMyAltProperty());
+        }
+    }
+}

--- a/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/properties/InterfaceWithProperties.java
+++ b/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/properties/InterfaceWithProperties.java
@@ -1,0 +1,32 @@
+package com.github.hypfvieh.dbus.examples.properties;
+
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+
+@DBusInterfaceName("com.acme.InterfaceWithProperties")
+public interface InterfaceWithProperties extends DBusInterface {
+
+    String sayHello();
+
+    int getJustAnInteger();
+
+    @DBusProperty(access = Access.READ, name = "MyProperty")
+    String getMyProperty();
+
+    @DBusProperty(access = Access.WRITE, name = "MyProperty")
+    void setMyProperty(String _property);
+
+    @DBusProperty(access = Access.READ, name = "ZZZZZZZ")
+    long getMyAltProperty();
+
+    @DBusProperty(access = Access.WRITE, name = "ZZZZZZZ")
+    void setMyAltProperty(long _property);
+
+    @DBusProperty
+    boolean isMyOtherProperty();
+
+    @DBusProperty
+    void setMyOtherProperty(boolean  _property);
+}

--- a/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/properties/ObjectWithProperties.java
+++ b/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/properties/ObjectWithProperties.java
@@ -1,0 +1,54 @@
+package com.github.hypfvieh.dbus.examples.properties;
+
+public class ObjectWithProperties implements InterfaceWithProperties {
+
+    private String myProperty = "Initial value";
+    private boolean myOtherProperty;
+    private long myAltProperty = 123;
+
+    @Override
+    public String getObjectPath() {
+        return "/com/acme/ObjectWithProperties";
+    }
+
+    @Override
+    public String sayHello() {
+        return "Hello!";
+    }
+
+    @Override
+    public long getMyAltProperty() {
+        return myAltProperty;
+    }
+
+    @Override
+    public void setMyAltProperty(long _myAltProperty) {
+        this.myAltProperty = _myAltProperty;
+    }
+
+    @Override
+    public int getJustAnInteger() {
+        return 99;
+    }
+
+    @Override
+    public String getMyProperty() {
+        return myProperty;
+    }
+
+    @Override
+    public void setMyProperty(String _property) {
+        myProperty = _property;
+    }
+
+    @Override
+    public boolean isMyOtherProperty() {
+        return myOtherProperty;
+    }
+
+    @Override
+    public void setMyOtherProperty(boolean _property) {
+        myOtherProperty = _property;
+    }
+
+}

--- a/dbus-java-utils/src/test/java/org/freedesktop/dbus/utils/generator/InterfaceCodeGeneratorTest.java
+++ b/dbus-java-utils/src/test/java/org/freedesktop/dbus/utils/generator/InterfaceCodeGeneratorTest.java
@@ -19,7 +19,7 @@ class InterfaceCodeGeneratorTest {
         if (!StringUtils.isBlank(_busName)) {
             String introspectionData = Util.readFileToString(_inputFile);
 
-            InterfaceCodeGenerator ci2 = new InterfaceCodeGenerator(false, introspectionData, _objectPath, _busName);
+            InterfaceCodeGenerator ci2 = new InterfaceCodeGenerator(false, introspectionData, _objectPath, _busName, null, false);
             return ci2;
         } else {
             fail("No valid busName given");


### PR DESCRIPTION
This patch makes it possible to map DBUS properties directly to setter / getter methods in any `DBusInterface`.  This has a number of advantages.

 * Less code. No need to implement `Get()`, `Set()` and `GetAll()` from `org.freedesktop.DBus.Properties`.  In fact, you do not need to implement this interface at all. 
 * More natural. Java programmers are familiar with this pattern, and I was finding every time I wanted to use properties, I had to go refresh my memory as to how dbus-java does it
 * Makes it much easier to share interfaces between client and server code. This was particularly difficult due to properties being wrapped in `Variant` on one side, but not the other.

If there is a disadvantage, it's that there is no equivalant of `GetAll()`. However, there is nothing stopping you mixing this new API with the old. So just implement `GetAll()` and stub out `Get()` and `Set()`.

This is what an interface with properties would now look like.

```java
@DBusInterfaceName("com.acme.InterfaceWithProperties")
public interface InterfaceWithProperties extends DBusInterface {

    String sayHello();

    int getJustAnInteger();

    @DBusProperty(access = Access.READ, name = "MyProperty")
    String getMyProperty();

    @DBusProperty(access = Access.WRITE, name = "MyProperty")
    void setMyProperty(String _property);

    @DBusProperty(access = Access.READ, name = "ZZZZZZZ")
    long getMyAltProperty();

    @DBusProperty(access = Access.WRITE, name = "ZZZZZZZ")
    void setMyAltProperty(long _property);

    @DBusProperty
    boolean isMyOtherProperty();

    @DBusProperty
    void setMyOtherProperty(boolean  _property);
}
```

And the implementation ..

```java
public class ObjectWithProperties implements InterfaceWithProperties {

    private String myProperty = "Initial value";
    private boolean myOtherProperty;
    private long myAltProperty = 123;

    @Override
    public String getObjectPath() {
        return "/com/acme/ObjectWithProperties";
    }

    @Override
    public String sayHello() {
        return "Hello!";
    }

    @Override
    public long getMyAltProperty() {
        return myAltProperty;
    }

    @Override
    public void setMyAltProperty(long _myAltProperty) {
        this.myAltProperty = _myAltProperty;
    }

    @Override
    public int getJustAnInteger() {
        return 99;
    }

    @Override
    public String getMyProperty() {
        return myProperty;
    }

    @Override
    public void setMyProperty(String _property) {
        myProperty = _property;
    }

    @Override
    public boolean isMyOtherProperty() {
        return myOtherProperty;
    }

    @Override
    public void setMyOtherProperty(boolean _property) {
        myOtherProperty = _property;
    }

}

```

Some points to note about the above.

 * `@DBusProperty` now may be attached to methods.
 * Any *method* with `@DBusProperty` will not be exported as a method, instead it and it's related setter or getter will be presented as a property.
 * When used on methods, all attributes of the annotation are optional. If not present, they will be inferred from the name itself, the parameter and return types and the name for access ("set*" will WRITE and "is" and "get" for READ). 

Other changes made. 

 * The code generator now has an option `--propertyMethods` that will generate codes using this method instead of class annotations.
 * `name` attribute of `@DBusProperty` was given a default value of `""`. Runtime checks are now used instead. This may be slightly controversial, but the alternative was using a totally separate annotation.
 * Also added a `--package` option to generate in a different namespace (and inject `@DBusInterfaceName`).
 * For my sanity, I refactored some of the code in `AbstractConnection`. This is where the most complex part of this patch was concentrated. Im 99% certain its functionally identical (apart from the new property features), but any review should pay particular attention here.


A new example has been added, but not yet tests. If you are happy with how this looks, I'll finish up with adding appropraite unit tests. 