### PR TITLE
Java language level syntactic sugaring

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/DBusMap.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/DBusMap.java
@@ -56,7 +56,7 @@ public class DBusMap<K, V> implements Map<K, V> {
     @SuppressWarnings("unchecked")
     public V get(Object _key) {
         for (Object[] entry : entries) {
-            if (_key == entry[0] || _key != null && _key.equals(entry[0])) {
+            if (Objects.equals(_key, entry[0])) {
                 return (V) entry[1];
             }
         }

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/DBusMatchRule.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/DBusMatchRule.java
@@ -255,10 +255,9 @@ public class DBusMatchRule {
         if (this == _obj) {
             return true;
         }
-        if (!(_obj instanceof DBusMatchRule)) {
+        if (!(_obj instanceof DBusMatchRule other)) {
             return false;
         }
-        DBusMatchRule other = (DBusMatchRule) _obj;
         return Objects.equals(iface, other.iface) && Objects.equals(member, other.member)
                 && Objects.equals(object, other.object) && Objects.equals(source, other.source)
                 && Objects.equals(type, other.type);

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/MethodTuple.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/MethodTuple.java
@@ -13,11 +13,7 @@ public class MethodTuple {
 
     public MethodTuple(String _name, String _sig) {
         name = _name;
-        if (null != _sig) {
-            sig = _sig;
-        } else {
-            sig = "";
-        }
+        sig = Objects.requireNonNullElse(_sig, "");
         logger.trace("new MethodTuple({}, {})", name, sig);
     }
 
@@ -31,10 +27,9 @@ public class MethodTuple {
         if (this == _obj) {
             return true;
         }
-        if (!(_obj instanceof MethodTuple)) {
+        if (!(_obj instanceof MethodTuple other)) {
             return false;
         }
-        MethodTuple other = (MethodTuple) _obj;
         return Objects.equals(name, other.name) && Objects.equals(sig, other.sig);
     }
 

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
@@ -54,7 +54,7 @@ public class RemoteInvocationHandler implements InvocationHandler {
         } else if (_method.getName().equals("equals")) {
             try {
                 if (1 == _args.length) {
-                    return Boolean.valueOf(_args[0] != null && remote.equals(((RemoteInvocationHandler) Proxy.getInvocationHandler(_args[0])).remote));
+                    return _args[0] != null && remote.equals(((RemoteInvocationHandler) Proxy.getInvocationHandler(_args[0])).remote);
                 }
             } catch (IllegalArgumentException _exIa) {
                 return Boolean.FALSE;
@@ -211,16 +211,16 @@ public class RemoteInvocationHandler implements InvocationHandler {
         }
 
         switch (_syncmethod) {
-            case CALL_TYPE_ASYNC:
+            case CALL_TYPE_ASYNC -> {
                 _conn.sendMessage(call);
                 return new DBusAsyncReply<>(call, _m, _conn);
-            case CALL_TYPE_CALLBACK:
+            }
+            case CALL_TYPE_CALLBACK -> {
                 _conn.queueCallback(call, _m, _callback);
                 _conn.sendMessage(call);
                 return null;
-            case CALL_TYPE_SYNC:
-                _conn.sendMessage(call);
-                break;
+            }
+            case CALL_TYPE_SYNC -> _conn.sendMessage(call);
         }
 
         // get reply

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/RemoteObject.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/RemoteObject.java
@@ -17,10 +17,9 @@ public class RemoteObject {
 
     @Override
     public boolean equals(Object _o) {
-        if (!(_o instanceof RemoteObject)) {
+        if (!(_o instanceof RemoteObject them)) {
             return false;
         }
-        RemoteObject them = (RemoteObject) _o;
 
         if (!them.objectpath.equals(this.objectpath)) {
             return false;

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/StructHelper.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/StructHelper.java
@@ -100,7 +100,7 @@ public final class StructHelper {
 
         Class<?>[] constructorArgClasses = Arrays.stream(_structType.getDeclaredFields())
             .filter(f -> f.isAnnotationPresent(Position.class))
-            .sorted((f1, f2) -> Integer.compare(f1.getAnnotation(Position.class).value(), f2.getAnnotation(Position.class).value()))
+            .sorted(Comparator.comparingInt(f -> f.getAnnotation(Position.class).value()))
             .map(Field::getType)
             .toArray(Class[]::new);
 
@@ -137,7 +137,7 @@ public final class StructHelper {
         }
 
         if (_variant.getType() instanceof DBusStructType && _variant.getValue() instanceof Object[]) {
-            Class<?>[] argTypes = Arrays.stream((Object[]) _variant.getValue()).map(Object::getClass).toArray(size -> new Class<?>[size]);
+            Class<?>[] argTypes = Arrays.stream((Object[]) _variant.getValue()).map(Object::getClass).toArray(Class<?>[]::new);
             return createStruct(argTypes, _variant.getValue(), _structClass);
         }
 

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/bin/DBusDaemon.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/bin/DBusDaemon.java
@@ -869,10 +869,9 @@ public class DBusDaemon extends Thread implements Closeable {
             if (this == _obj) {
                 return true;
             }
-            if (!(_obj instanceof Pair)) {
+            if (!(_obj instanceof Pair<?, ?> other)) {
                 return false;
             }
-            Pair<?, ?> other = (Pair<?, ?>) _obj;
             return Objects.equals(first, other.first) && Objects.equals(second, other.second);
         }
 

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/AbstractConnection.java
@@ -412,7 +412,7 @@ public abstract non-sealed class AbstractConnection extends ConnectionMessageHan
             return null;
         }
         return Arrays.stream(_parameters)
-                .filter(p -> p != null) // do no try to convert null values to concrete class
+                .filter(Objects::nonNull) // do no try to convert null values to concrete class
                 .map(p -> {
                     if (List.class.isAssignableFrom(p.getClass())) { // turn possible List subclasses (e.g. ArrayList) to interface class List
                         return List.class;

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/base/AbstractConnectionBase.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/base/AbstractConnectionBase.java
@@ -170,7 +170,7 @@ public abstract sealed class AbstractConnectionBase implements Closeable permits
             m = getTransport().readMessage();
         } catch (IOException _exIo) {
             if (_exIo instanceof EOFException || _exIo instanceof ClosedByInterruptException) {
-                disconnectCallback.ifPresent(cb -> cb.clientDisconnect());
+                disconnectCallback.ifPresent(IDisconnectCallback::clientDisconnect);
                 if (disconnecting // when we are already disconnecting, ignore further errors
                     || getBusAddress().isListeningSocket()) { // when we are listener, a client may disconnect any time which
                                                          // is no error

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
@@ -572,13 +572,7 @@ public final class DBusConnection extends AbstractConnection {
             throws DBusException {
         validateSignal(_type, _source);
         addSigHandler(new DBusMatchRule(_type, _source, null), (DBusSigHandler<? extends DBusSignal>) _handler);
-        return new AutoCloseable() {
-
-            @Override
-            public void close() throws DBusException {
-                removeSigHandler(_type, _source, _handler);
-            }
-        };
+        return () -> removeSigHandler(_type, _source, _handler);
     }
 
     /**
@@ -609,12 +603,7 @@ public final class DBusConnection extends AbstractConnection {
         String objectPath = getImportedObjects().get(_object).getObjectPath();
         DBusObjects.requireObjectPath(objectPath);
         addSigHandler(new DBusMatchRule(_type, _source, objectPath), (DBusSigHandler<? extends DBusSignal>) _handler);
-        return new AutoCloseable() {
-            @Override
-            public void close() throws DBusException {
-                removeSigHandler(_type, _source, _object, _handler);
-            }
-        };
+        return () -> removeSigHandler(_type, _source, _object, _handler);
     }
 
     /**
@@ -664,12 +653,7 @@ public final class DBusConnection extends AbstractConnection {
                 throw new DBusException("Cannot add match rule.", _ex);
             }
         }
-        return new AutoCloseable() {
-            @Override
-            public void close() throws DBusException {
-                removeSigHandler(_rule, _handler);
-            }
-        };
+        return () -> removeSigHandler(_rule, _handler);
     }
 
     /**
@@ -728,7 +712,7 @@ public final class DBusConnection extends AbstractConnection {
                 // remove all exported objects before disconnecting
                 Map<String, ExportedObject> exportedObjects = getExportedObjects();
                 synchronized (exportedObjects) {
-                    List<String> exportedKeys = exportedObjects.keySet().stream().filter(f -> f != null).collect(Collectors.toList());
+                    List<String> exportedKeys = exportedObjects.keySet().stream().filter(Objects::nonNull).collect(Collectors.toList());
                     for (String key : exportedKeys) {
                         unExportObject(key);
                     }
@@ -794,12 +778,7 @@ public final class DBusConnection extends AbstractConnection {
                 throw new DBusException(_ex.getMessage());
             }
         }
-        return new AutoCloseable() {
-            @Override
-            public void close() throws DBusException {
-                removeGenericSigHandler(_rule, _handler);
-            }
-        };
+        return () -> removeGenericSigHandler(_rule, _handler);
     }
 
     private final class SigHandler implements DBusSigHandler<DBusSignal> {

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/exceptions/DBusExecutionException.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/exceptions/DBusExecutionException.java
@@ -1,5 +1,7 @@
 package org.freedesktop.dbus.exceptions;
 
+import java.util.Objects;
+
 /**
  * An exception while running a remote method within DBus.
  */
@@ -37,10 +39,6 @@ public class DBusExecutionException extends RuntimeException {
     * @return string
     */
     public String getType() {
-        if (null == type) {
-            return getClass().getName();
-        } else {
-            return type;
-        }
+        return Objects.requireNonNullElseGet(type, () -> getClass().getName());
     }
 }

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/messages/Message.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/messages/Message.java
@@ -520,7 +520,7 @@ public class Message {
                 appendByte(((Number) _data).byteValue());
                 break;
             case BOOLEAN:
-                appendint(((Boolean) _data).booleanValue() ? 1 : 0, 4);
+                appendint((Boolean) _data ? 1 : 0, 4);
                 break;
             case DOUBLE:
                 long l = Double.doubleToLongBits(((Number) _data).doubleValue());
@@ -614,41 +614,40 @@ public class Message {
                     int algn = getAlignment(_sigb[i]);
                     int len = Array.getLength(_data);
                     switch (_sigb[i]) {
-                        case BYTE:
-                        primbuf = (byte[]) _data;
-                        break;
-                    case INT16, INT32, INT64:
-                        primbuf = new byte[len * algn];
-                        for (int j = 0, k = 0; j < len; j++, k += algn) {
-                            marshallint(Array.getLong(_data, j), primbuf, k, algn);
+                        case BYTE -> {
+                            primbuf = (byte[]) _data;
                         }
-                        break;
-                    case BOOLEAN:
-                        primbuf = new byte[len * algn];
-                        for (int j = 0, k = 0; j < len; j++, k += algn) {
-                            marshallint(Array.getBoolean(_data, j) ? 1 : 0, primbuf, k, algn);
-                        }
-                        break;
-                    case DOUBLE:
-                        primbuf = new byte[len * algn];
-                        if (_data instanceof float[] fa) {
+                        case INT16, INT32, INT64 -> {
+                            primbuf = new byte[len * algn];
                             for (int j = 0, k = 0; j < len; j++, k += algn) {
-                                marshallint(Double.doubleToRawLongBits(fa[j]), primbuf, k, algn);
-                            }
-                        } else {
-                            for (int j = 0, k = 0; j < len; j++, k += algn) {
-                                marshallint(Double.doubleToRawLongBits(((double[]) _data)[j]), primbuf, k, algn);
+                                marshallint(Array.getLong(_data, j), primbuf, k, algn);
                             }
                         }
-                        break;
-                    case FLOAT:
-                        primbuf = new byte[len * algn];
-                        for (int j = 0, k = 0; j < len; j++, k += algn) {
-                            marshallint(Float.floatToRawIntBits(((float[]) _data)[j]), primbuf, k, algn);
+                        case BOOLEAN -> {
+                            primbuf = new byte[len * algn];
+                            for (int j = 0, k = 0; j < len; j++, k += algn) {
+                                marshallint(Array.getBoolean(_data, j) ? 1 : 0, primbuf, k, algn);
+                            }
                         }
-                        break;
-                    default:
-                        throw new MarshallingException("Primitive array being sent as non-primitive array.");
+                        case DOUBLE -> {
+                            primbuf = new byte[len * algn];
+                            if (_data instanceof float[] fa) {
+                                for (int j = 0, k = 0; j < len; j++, k += algn) {
+                                    marshallint(Double.doubleToRawLongBits(fa[j]), primbuf, k, algn);
+                                }
+                            } else {
+                                for (int j = 0, k = 0; j < len; j++, k += algn) {
+                                    marshallint(Double.doubleToRawLongBits(((double[]) _data)[j]), primbuf, k, algn);
+                                }
+                            }
+                        }
+                        case FLOAT -> {
+                            primbuf = new byte[len * algn];
+                            for (int j = 0, k = 0; j < len; j++, k += algn) {
+                                marshallint(Float.floatToRawIntBits(((float[]) _data)[j]), primbuf, k, algn);
+                            }
+                        }
+                        default -> throw new MarshallingException("Primitive array being sent as non-primitive array.");
                     }
                     appendBytes(primbuf);
                 } else if (_data instanceof List<?> lst) {

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/types/Variant.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/types/Variant.java
@@ -137,10 +137,9 @@ public class Variant<T> {
         if (this == _obj) {
             return true;
         }
-        if (!(_obj instanceof Variant<?>)) {
+        if (!(_obj instanceof Variant<?> other)) {
             return false;
         }
-        Variant<?> other = (Variant<?>) _obj;
         return  Objects.equals(value, other.value);
     }
 

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/AddressBuilder.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/AddressBuilder.java
@@ -132,7 +132,7 @@ public final class AddressBuilder {
         List<String> locationPriorityList = Arrays.asList(System.getenv(DBusSysProps.DBUS_MACHINE_ID_SYS_VAR), _dbusMachineIdFile,
                 "/var/lib/dbus/machine-id", "/usr/local/var/lib/dbus/machine-id", "/etc/machine-id");
         return locationPriorityList.stream()
-                .filter(s -> s != null)
+                .filter(Objects::nonNull)
                 .map(File::new)
                 .filter(f -> f.exists() && f.length() > 0)
                 .findFirst()

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/TimeMeasure.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/TimeMeasure.java
@@ -31,12 +31,7 @@ public class TimeMeasure {
      * Create a new instance, used a formatter converting everything &gt;= 5000 ms to seconds (X.Y -&gt; 6.1).
      */
     public TimeMeasure() {
-        this(new ITimeMeasureFormat() {
-            @Override
-            public String format(long _durationInMillis) {
-                return _durationInMillis >= 5000 ? ((long) ((_durationInMillis / 1000d) * 10) / 10d) + "s" : _durationInMillis + "ms";
-            }
-        });
+        this(_durationInMillis -> _durationInMillis >= 5000 ? ((long) ((_durationInMillis / 1000d) * 10) / 10d) + "s" : _durationInMillis + "ms");
     }
 
     /**

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/Util.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/Util.java
@@ -439,8 +439,8 @@ public final class Util {
      */
     public static String getCurrentUser() {
         String[] sysPropParms = new String[] {"user.name", "USER", "USERNAME"};
-        for (int i = 0; i < sysPropParms.length; i++) {
-            String val = System.getProperty(sysPropParms[i]);
+        for (String sysPropParm : sysPropParms) {
+            String val = System.getProperty(sysPropParm);
             if (!isEmpty(val)) {
                 return val;
             }

--- a/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/nested/data/MyObject.java
+++ b/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/nested/data/MyObject.java
@@ -25,6 +25,6 @@ public class MyObject implements MyInterface {
 
     @Override
     public List<String> getPartNames() {
-        return parts.stream().map(i -> i.getVal1()).collect(Collectors.toList());
+        return parts.stream().map(MyInterfacePart::getVal1).collect(Collectors.toList());
     }
 }

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/connections/base/ReceivingServiceTest.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/connections/base/ReceivingServiceTest.java
@@ -89,12 +89,7 @@ class ReceivingServiceTest extends AbstractBaseTest {
      */
     @Test
     void testRetryHandlerHardLimit() {
-        IThreadPoolRetryHandler handler = new IThreadPoolRetryHandler() {
-            @Override
-            public boolean handle(ExecutorNames _executor, Exception _ex) {
-                return true;
-            }
-        };
+        IThreadPoolRetryHandler handler = (_executor, _ex) -> true;
 
         ReceivingServiceConfig build = new ReceivingServiceConfigBuilder<>(null).withRetryHandler(handler).build();
 
@@ -139,13 +134,9 @@ class ReceivingServiceTest extends AbstractBaseTest {
     @Test
     void testRetryHandlerNotCalledBecauseNoFailure() {
         AtomicBoolean handlerWasCalled = new AtomicBoolean();
-        IThreadPoolRetryHandler handler = new IThreadPoolRetryHandler() {
-
-            @Override
-            public boolean handle(ExecutorNames _executor, Exception _ex) {
-                handlerWasCalled.set(true);
-                return true;
-            }
+        IThreadPoolRetryHandler handler = (_executor, _ex) -> {
+            handlerWasCalled.set(true);
+            return true;
         };
 
         ReceivingServiceConfig build = new ReceivingServiceConfigBuilder<>(null).withRetryHandler(handler).build();

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/ComplexTest.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/ComplexTest.java
@@ -25,9 +25,7 @@ public class ComplexTest extends AbstractDBusBaseTest {
     @Test
     public void testDbusIgnore() throws DBusException {
         SampleRemoteInterface tri = (SampleRemoteInterface) clientconn.getPeerRemoteObject(getTestBusName(), getTestObjectPath());
-        assertThrowsExactly(UnknownMethod.class, () -> {
-            tri.thisShouldBeIgnored();
-        });
+        assertThrowsExactly(UnknownMethod.class, tri::thisShouldBeIgnored);
     }
 
     public void testFrob() throws DBusException {
@@ -59,7 +57,7 @@ public class ComplexTest extends AbstractDBusBaseTest {
         SampleTuple<String, List<Integer>, Boolean> rv = tri2.show(234);
         logger.debug("Show returned: " + rv);
         if (!clientconn.getUniqueName().equals(rv.getFirstValue()) || 1 != rv.getSecondValue().size() || 1953 != rv.getSecondValue().get(0)
-                || !rv.getThirdValue().booleanValue()) {
+                || !rv.getThirdValue()) {
             fail("show return value incorrect (" + rv.getFirstValue() + "," + rv.getSecondValue() + "," + rv.getThirdValue() + ")");
         }
 

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/ExportNestedTest.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/ExportNestedTest.java
@@ -87,7 +87,7 @@ public class ExportNestedTest extends AbstractDBusDaemonBaseTest {
 
         @Override
         public List<String> getPartNames() {
-            return parts.stream().map(i -> i.getVal1()).collect(Collectors.toList());
+            return parts.stream().map(MyInterfacePart::getVal1).collect(Collectors.toList());
         }
     }
 

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/HandlerTest.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/HandlerTest.java
@@ -109,13 +109,13 @@ public class HandlerTest extends AbstractDBusBaseTest {
         assertEquals(1, psh.getActualTestRuns(), "PathSignalHandler should have been called");
         assertEquals(1, osh.getActualTestRuns(), "ObjectSignalHandler should have been called");
 
-        assertDoesNotThrow(() -> sigh.throwAssertionError());
-        assertDoesNotThrow(() -> esh.throwAssertionError());
-        assertDoesNotThrow(() -> rsh.throwAssertionError());
-        assertDoesNotThrow(() -> ash.throwAssertionError());
-        assertDoesNotThrow(() -> ensh.throwAssertionError());
-        assertDoesNotThrow(() -> psh.throwAssertionError());
-        assertDoesNotThrow(() -> osh.throwAssertionError());
+        assertDoesNotThrow(sigh::throwAssertionError);
+        assertDoesNotThrow(esh::throwAssertionError);
+        assertDoesNotThrow(rsh::throwAssertionError);
+        assertDoesNotThrow(ash::throwAssertionError);
+        assertDoesNotThrow(ensh::throwAssertionError);
+        assertDoesNotThrow(psh::throwAssertionError);
+        assertDoesNotThrow(osh::throwAssertionError);
 
         /** Remove sig handler */
         clientconn.removeSigHandler(SampleSignals.TestSignal.class, sigh);

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/SignalNameTest.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/SignalNameTest.java
@@ -9,7 +9,6 @@ import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
 import org.freedesktop.dbus.connections.transports.TransportBuilder;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.interfaces.DBusInterface;
-import org.freedesktop.dbus.interfaces.DBusSigHandler;
 import org.freedesktop.dbus.messages.DBusSignal;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
@@ -46,12 +45,7 @@ public class SignalNameTest extends AbstractBaseTest {
                 connection.requestBusName("d.e.f.Service");
                 connection.exportObject("/d/e/f/custom", new MyCustomImpl());
 
-                connection.addSigHandler(CustomService.CustomSignal.class, new DBusSigHandler<CustomService.CustomSignal>() {
-                    @Override
-                    public void handle(CustomService.CustomSignal _s) {
-                        logger.debug("Received signal: {}", _s.data);
-                    }
-                });
+                connection.addSigHandler(CustomService.CustomSignal.class, _s -> logger.debug("Received signal: {}", _s.data));
 
                 connection.sendMessage(new CustomService.CustomSignal("/a/b/c/custom", "hello world"));
                 // wait to deliver message

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/StressTest.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/StressTest.java
@@ -30,7 +30,7 @@ public class StressTest extends AbstractDBusDaemonBaseTest {
     @AfterEach
     public void tearDown() throws Exception {
         Collections.reverse(closeables);
-        closeables.forEach(closeable -> runUnchecked(() -> closeable.close()));
+        closeables.forEach(closeable -> runUnchecked(closeable::close));
     }
 
     @Test

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ArrayStructIntStruct.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ArrayStructIntStruct.java
@@ -33,7 +33,7 @@ public final class ArrayStructIntStruct extends Struct implements IEmptyCollecti
     @Override
     public String getStringTestValue() {
         return Stream.of(list)
-                .map(i -> i.toSimpleString())
+                .map(IntStruct::toSimpleString)
                 .collect(Collectors.joining(","));
     }
 

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ArrayStructPrimitive.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ArrayStructPrimitive.java
@@ -31,7 +31,7 @@ public final class ArrayStructPrimitive extends Struct implements IEmptyCollecti
 
     @Override
     public String getStringTestValue() {
-        return IntStream.of(list).mapToObj(i -> Integer.toString(i)).collect(Collectors.joining(","));
+        return IntStream.of(list).mapToObj(Integer::toString).collect(Collectors.joining(","));
     }
 
     @Override

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListMapStruct.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListMapStruct.java
@@ -34,14 +34,14 @@ public final class ListMapStruct extends Struct implements IEmptyCollectionStruc
     @Override
     public String getStringTestValue() {
         return list.stream()
-                .map(m -> toPrintableMap(m))
+                .map(this::toPrintableMap)
                 .collect(Collectors.toList())
                 .toString();
     }
 
     private Map<String, String> toPrintableMap(Map<String, IntStruct> _m) {
         return _m.entrySet().stream()
-                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toSimpleString()));
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toSimpleString()));
     }
 
     @Override

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListStructPrimitive.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListStructPrimitive.java
@@ -31,7 +31,7 @@ public final class ListStructPrimitive extends Struct implements IEmptyCollectio
 
     @Override
     public String getStringTestValue() {
-        return list.stream().map(i -> i.toString()).collect(Collectors.joining(","));
+        return list.stream().map(Object::toString).collect(Collectors.joining(","));
     }
 
     @Override

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListStructStruct.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/ListStructStruct.java
@@ -33,7 +33,7 @@ public final class ListStructStruct extends Struct implements IEmptyCollectionSt
     @Override
     public String getStringTestValue() {
         return list.stream()
-                .map(i -> i.toSimpleString())
+                .map(IntStruct::toSimpleString)
                 .collect(Collectors.joining(","));
     }
 

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/MapArrayStruct.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/collections/empty/structs/MapArrayStruct.java
@@ -34,12 +34,12 @@ public final class MapArrayStruct extends Struct implements IEmptyCollectionStru
     @Override
     public String getStringTestValue() {
         return map.entrySet().stream()
-                .collect(Collectors.toMap(e -> e.getKey(), e -> toPrintableArray(e.getValue())))
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> toPrintableArray(e.getValue())))
                 .toString();
     }
 
     private String toPrintableArray(IntStruct[] _array) {
-        String values = Stream.of(_array).map(e -> e.toSimpleString())
+        String values = Stream.of(_array).map(IntStruct::toSimpleString)
                 .collect(Collectors.joining(","));
         return String.format("[%s]", values);
     }

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/Profile.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/Profile.java
@@ -273,9 +273,7 @@ public final class Profile {
                 len = 256;
                 while (len <= 32768) {
                     StringBuilder sb = new StringBuilder();
-                    for (int i = 0; i < len; i++) {
-                        sb.append('a');
-                    }
+                    sb.append("a".repeat(len));
                     String s = sb.toString();
                     end = System.currentTimeMillis() + 500;
                     count = 0;

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/SampleClass.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/SampleClass.java
@@ -94,7 +94,7 @@ public class SampleClass implements SampleRemoteInterface, SampleRemoteInterface
     @Override
     public <A> SampleTuple<String, List<Integer>, Boolean> show(A _in) {
         logger.debug("Showing Stuff: " + _in.getClass() + "(" + _in + ")");
-        if (!(_in instanceof Integer) || ((Integer) _in).intValue() != 234) {
+        if (!(_in instanceof Integer) || (Integer) _in != 234) {
             fail("show received the wrong arguments");
         }
         DBusCallInfo info = AbstractConnection.getCallInfo();
@@ -112,7 +112,7 @@ public class SampleClass implements SampleRemoteInterface, SampleRemoteInterface
                 || !(_foo.getInt32Value() instanceof UInt32) || !(_foo.getVariantValue() instanceof Variant)
                 || !"bar".equals(_foo.getStringValue()) || _foo.getInt32Value().intValue() != 52
                 || !(_foo.getVariantValue().getValue() instanceof Boolean)
-                || !((Boolean) _foo.getVariantValue().getValue()).booleanValue()) {
+                || !(Boolean) _foo.getVariantValue().getValue()) {
             fail("dostuff received the wrong arguments");
         }
         return (T) _foo.getVariantValue().getValue();
@@ -143,7 +143,7 @@ public class SampleClass implements SampleRemoteInterface, SampleRemoteInterface
         for (Integer i : _is) {
             logger.debug("--" + i);
         }
-        if (_is.length != 4 || _is[0].intValue() != 1 || _is[1].intValue() != 5 || _is[2].intValue() != 7 || _is[3].intValue() != 9) {
+        if (_is.length != 4 || _is[0] != 1 || _is[1] != 5 || _is[2] != 7 || _is[3] != 9) {
             fail("sampleArray, Integer array contents incorrect");
         }
         logger.debug("Got an array:");

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/cross/CrossTestClient.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/cross/CrossTestClient.java
@@ -74,11 +74,7 @@ public class CrossTestClient implements Binding.SampleClient, DBusSigHandler<Bin
 
     public void fail(String _test, String _reason) {
         String test = _test.replaceAll("[$]", ".");
-        List<String> reasons = failed.get(test);
-        if (null == reasons) {
-            reasons = new ArrayList<>();
-            failed.put(test, reasons);
-        }
+        List<String> reasons = failed.computeIfAbsent(test, k -> new ArrayList<>());
         reasons.add(_reason);
     }
 
@@ -135,15 +131,12 @@ public class CrossTestClient implements Binding.SampleClient, DBusSigHandler<Bin
                     fail(_iface.getName() + "." + _method, msg);
                 }
             } else {
-                if (o == _rv || o != null && o.equals(_rv)) {
+                if (Objects.equals(o, _rv)) {
                     pass(_iface.getName() + "." + _method);
                 } else {
                     fail(_iface.getName() + "." + _method, msg);
                 }
             }
-        } catch (DBusExecutionException _exDbe) {
-            _exDbe.printStackTrace();
-            fail(_iface.getName() + "." + _method, "Error occurred during execution: " + _exDbe.getClass().getName() + " " + _exDbe.getMessage());
         } catch (InvocationTargetException _exIt) {
             _exIt.printStackTrace();
             fail(_iface.getName() + "." + _method, "Error occurred during execution: " + _exIt.getCause().getClass().getName() + " " + _exIt.getCause().getMessage());
@@ -302,7 +295,7 @@ public class CrossTestClient implements Binding.SampleClient, DBusSigHandler<Bin
             fail("org.freedesktop.DBus.Introspectable.Introspect", "Got exception during introspection on / (" + _ex.getClass().getName() + "): " + _ex.getMessage());
         }
 
-        test(SamplesInterface.class, _tests, "Identity", new Variant<>(Integer.valueOf(1)), new Variant<>(Integer.valueOf(1)));
+        test(SamplesInterface.class, _tests, "Identity", new Variant<>(1), new Variant<>(1));
         test(SamplesInterface.class, _tests, "Identity", new Variant<>("Hello"), new Variant<>("Hello"));
 
         test(SamplesInterface.class, _tests, "IdentityBool", false, false);
@@ -420,8 +413,8 @@ public class CrossTestClient implements Binding.SampleClient, DBusSigHandler<Bin
 
         test(SamplesInterface.class, _tests, "DeStruct",
                 new Binding.Triplet<>("hi", new UInt32(12),
-                        Short.valueOf((short) 99)), new CrossSampleStruct("hi", new UInt32(12),
-                                Short.valueOf((short) 99)));
+                        (short) 99), new CrossSampleStruct("hi", new UInt32(12),
+                        (short) 99));
 
         Map<String, String> in = new HashMap<>();
         Map<String, List<String>> out = new HashMap<>();
@@ -443,7 +436,7 @@ public class CrossTestClient implements Binding.SampleClient, DBusSigHandler<Bin
         out.put("out", l);
         test(SamplesInterface.class, _tests, "InvertMapping", out, in);
 
-        primitizeTest(_tests, Integer.valueOf(1));
+        primitizeTest(_tests, 1);
         primitizeTest(_tests, new Variant<>(new Variant<>(new Variant<>(new Variant<>("Hi")))));
         primitizeTest(_tests, new Variant<>(in, new DBusMapType(String.class, String.class)));
 

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/cross/CrossTestServer.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/cross/CrossTestServer.java
@@ -308,11 +308,7 @@ public class CrossTestServer implements SamplesInterface, SingleSample, DBusSigH
         Map<String, List<String>> m = new HashMap<>();
         for (String s : _a.keySet()) {
             String b = _a.get(s);
-            List<String> l = m.get(b);
-            if (null == l) {
-                l = new ArrayList<>();
-                m.put(b, l);
-            }
+            List<String> l = m.computeIfAbsent(b, k -> new ArrayList<>());
             l.add(s);
         }
         return m;

--- a/dbus-java-tests/src/test/java/sample/issue/Issue196Test.java
+++ b/dbus-java-tests/src/test/java/sample/issue/Issue196Test.java
@@ -39,13 +39,7 @@ public class Issue196Test extends AbstractBaseTest {
                 RemoteInvocationHandler rih = null;
 
                 connection.requestBusName(source);
-                connection.exportObject(path, new TestInterfaceType() {
-
-                    @Override
-                    public String getObjectPath() {
-                        return path;
-                    }
-                });
+                connection.exportObject(path, (TestInterfaceType) () -> path);
 
                 dbi = connection.dynamicProxy(source, path, null);
                 assertNotNull(dbi);

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/ClassBuilderInfo.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/ClassBuilderInfo.java
@@ -178,7 +178,7 @@ public class ClassBuilderInfo {
             bgn += " extends " + getSimpleTypeClasses(getExtendClass());
         }
         if (!getImplementedInterfaces().isEmpty()) {
-            bgn += " implements " + getImplementedInterfaces().stream().map(e -> getClassName(e)).collect(Collectors.joining(", "));
+            bgn += " implements " + getImplementedInterfaces().stream().map(ClassBuilderInfo::getClassName).collect(Collectors.joining(", "));
             // add classes import if implements-arguments are not a java.lang. classes
             getImports().addAll(getImplementedInterfaces().stream().filter(s -> !s.startsWith("java.lang.")).collect(Collectors.toList()));
         }
@@ -228,7 +228,7 @@ public class ClassBuilderInfo {
                 String innerIndent = _staticClass ? "            " : "        ";
 
                 if (!constructor.getSuperArguments().isEmpty()) {
-                    content.add(innerIndent + "super(" + constructor.getSuperArguments().stream().map(c -> c.getName()).collect(Collectors.joining(", ")) + ");");
+                    content.add(innerIndent + "super(" + constructor.getSuperArguments().stream().map(MemberOrArgument::getName).collect(Collectors.joining(", ")) + ");");
                 }
 
                 if (!constructor.getArguments().isEmpty()) {
@@ -365,7 +365,7 @@ public class ClassBuilderInfo {
         if (_type == null) {
             return null;
         }
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         Pattern compile = Pattern.compile("([^, <>?]+)");
         Matcher matcher = compile.matcher(_type);
         while (matcher.find()) {

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/InterfaceCodeGenerator.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/InterfaceCodeGenerator.java
@@ -171,15 +171,9 @@ public class InterfaceCodeGenerator {
         List<Element> interfaceElements = convertToElementList(_ife.getChildNodes());
         for (Element element : interfaceElements) {
             switch (element.getTagName().toLowerCase()) {
-            case "method":
-                additionalClasses.addAll(extractMethods(element, interfaceClass));
-                break;
-            case "property":
-                additionalClasses.addAll(extractProperties(element, interfaceClass));
-                break;
-            case "signal":
-                additionalClasses.addAll(extractSignals(element, interfaceClass));
-                break;
+                case "method"   -> additionalClasses.addAll(extractMethods(element, interfaceClass));
+                case "property" -> additionalClasses.addAll(extractProperties(element, interfaceClass));
+                case "signal"   -> additionalClasses.addAll(extractSignals(element, interfaceClass));
             }
         }
 

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/StructTreeBuilder.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/StructTreeBuilder.java
@@ -128,7 +128,7 @@ public class StructTreeBuilder {
                 if (x != null) {
                     member.getGenerics().add(x.getClassName());
                 } else {
-                    member.getGenerics().addAll(temp.getMembers().stream().map(l -> l.getType()).collect(Collectors.toList()));
+                    member.getGenerics().addAll(temp.getMembers().stream().map(MemberOrArgument::getType).collect(Collectors.toList()));
                 }
                 root.getImports().addAll(temp.getImports());
 

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/TypeConverter.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/generator/TypeConverter.java
@@ -115,24 +115,16 @@ public final class TypeConverter {
      * @return primitive or original input
      */
     private static String convertJavaBoxedTypeToPrimitive(String _clazzName) {
-        switch (_clazzName) {
-        case "Boolean":
-            return "boolean";
-        case "Integer":
-            return "int";
-        case "Long":
-            return "long";
-        case "Double":
-            return "double";
-        case "Float":
-            return "float";
-        case "Byte":
-            return "byte";
-        case "Char":
-            return "char";
-        default:
-            return _clazzName;
-        }
+        return switch (_clazzName) {
+            case "Boolean" -> "boolean";
+            case "Integer" -> "int";
+            case "Long"    -> "long";
+            case "Double"  -> "double";
+            case "Float"   -> "float";
+            case "Byte"    -> "byte";
+            case "Char"    -> "char";
+            default        -> _clazzName;
+        };
     }
 
     /**

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/translator/DBusTypeStringToJava.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/utils/translator/DBusTypeStringToJava.java
@@ -71,16 +71,17 @@ public final class DBusTypeStringToJava {
     }
 
     private static void recursive(Type _t, int _indent) {
+        String indent = INDENT.repeat(Math.max(0, _indent));
         if (_t instanceof DBusListType l) {
-            System.out.println(repeat(INDENT, _indent) + List.class.getName());
+            System.out.println(indent + List.class.getName());
             Type type = l.getActualTypeArguments()[0];
             recursive(type, _indent + 1);
         } else if (_t instanceof DBusMapType m) {
-            System.out.println(repeat(INDENT, _indent) + Map.class.getName());
+            System.out.println(indent + Map.class.getName());
             recursive(m.getActualTypeArguments()[0], _indent + 2);
             recursive(m.getActualTypeArguments()[1], _indent + 2);
         } else if (_t instanceof DBusStructType s) {
-            System.out.println(repeat(INDENT, _indent) + Struct.class.getName());
+            System.out.println(indent + Struct.class.getName());
             for (Type ty : s.getActualTypeArguments()) {
                 recursive(ty, _indent + 2);
             }
@@ -89,22 +90,7 @@ public final class DBusTypeStringToJava {
             if ("java.lang.CharSequence".equals(str)) {
                 str = String.class.getName();
             }
-            System.out.println(repeat(INDENT, _indent) + str);
+            System.out.println(indent + str);
         }
-    }
-
-    /**
-     * Repeat the given String given count times.
-     *
-     * @param _string string to repeat
-     * @param _cnt count
-     * @return repeated string
-     */
-    private static String repeat(String _string, int _cnt) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < _cnt; i++) {
-            sb.append(_string);
-        }
-        return sb.toString();
     }
 }

--- a/dbus-java-utils/src/main/java/org/freedesktop/dbus/viewer/DBusTableModel.java
+++ b/dbus-java-utils/src/main/java/org/freedesktop/dbus/viewer/DBusTableModel.java
@@ -74,16 +74,13 @@ class DBusTableModel extends AbstractTableModel {
         if (columnName.equals(NAME)) {
             return String.class;
         }
-        if (columnName.equals(PATH)) {
-            return String.class;
-        } else if (columnName.equals(USER)) {
-            return Object.class;
-        } else if (columnName.equals(OWNER)) {
-            return String.class;
-        } else if (columnName.equals(INTROSPECTABLE)) {
-            return Boolean.class;
-        }
-        return super.getColumnClass(_columnIndex);
+        return switch (columnName) {
+            case PATH  -> String.class;
+            case USER  -> Object.class;
+            case OWNER -> String.class;
+            case INTROSPECTABLE -> Boolean.class;
+            default -> super.getColumnClass(_columnIndex);
+        };
     }
 
     /** {@inheritDoc} */
@@ -94,16 +91,13 @@ class DBusTableModel extends AbstractTableModel {
         if (columnName.equals(NAME)) {
             return entry.getName();
         }
-        if (columnName.equals(PATH)) {
-            return entry.getPath();
-        } else if (columnName.equals(USER)) {
-            return entry.getUser();
-        } else if (columnName.equals(OWNER)) {
-            return entry.getOwner();
-        } else if (columnName.equals(INTROSPECTABLE)) {
-            return entry.getIntrospectable() != null;
-        }
-        return null;
+        return switch (columnName) {
+            case PATH  -> entry.getPath();
+            case USER  -> entry.getUser();
+            case OWNER -> entry.getOwner();
+            case INTROSPECTABLE -> entry.getIntrospectable() != null;
+            default -> null;
+        };
     }
 
 }


### PR DESCRIPTION
Non-functional change - make use of new Java language features available up to Java 17 LTS

- Use String.repeat()
- Replace statements with enhanced switch
- Use pattern variable
- Convert to enhanced for-loop
- Prefer StringBuilder over StringBuffer
- Remove unnecessary boxing/unboxing
- Use Objects.equals() rather than equals() expression
- Replace explicit types by diamond operator
- Use lambdas for anonymous types
- Use Comparator combinator
- Introduce method references for lambdas
- Change statement to expression lambdas
- Check for null using method call