### PR TITLE
Exported objects that use `@DBusBoundProperty` only do not export `org.freedesktop.DBus.Properties`

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/messages/ExportedObject.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/messages/ExportedObject.java
@@ -9,6 +9,7 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.DBusInterface;
 import org.freedesktop.dbus.interfaces.Introspectable;
 import org.freedesktop.dbus.interfaces.Peer;
+import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.propertyref.PropertyRef;
 import org.freedesktop.dbus.utils.DBusNamingUtil;
 import org.freedesktop.dbus.utils.Util;
@@ -306,6 +307,17 @@ public class ExportedObject {
             if (interfaces.contains(DBusInterface.class)) {
                 // clazz is interface and directly extends the DBusInterface
                 result.add(clazz);
+            }
+
+            if (!checked.contains(Properties.class)) {
+                for (Method method : clazz.getDeclaredMethods()) {
+                    DBusBoundProperty propertyAnnot = method.getAnnotation(DBusBoundProperty.class);
+                    if (propertyAnnot != null) {
+                        // clazz is using @DBusBoundProperty, always exposed the properties interface
+                        toCheck.add(Properties.class);
+                        break;
+                    }
+                }
             }
 
             // iterate over the sub-interfaces and select the ones that extend DBusInterface


### PR DESCRIPTION
If an interface uses this annotation, but doesn't implement `org.freedesktop.dbus.interfaces.Properties`, then no introspection data will be generated for  `org.freedesktop.DBus.Properties`. 

This patch will automatically generate the introspection data for this interface if a `@DBusBoundProperty` annotation is found on any method in the class. 

Note that this doesn't actually stop the properties from working, but this generic interface should always be exported. All other services do.

After fix ...

![after-export-fix](https://github.com/hypfvieh/dbus-java/assets/10938912/3d22a456-92f2-4d6f-ada0-3eb8e7fa7f2a)

Before fix ..

![before-export-fix](https://github.com/hypfvieh/dbus-java/assets/10938912/0ceceb3e-ffe3-4f9e-996e-9c0e2b2400e9)
