### PR TITLE
Handle wildcard types to support Kotlin better

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/Marshalling.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/Marshalling.java
@@ -200,7 +200,9 @@ public final class Marshalling {
             throw new DBusException(_dataType + " is not a basic type");
         }
 
-        if (_dataType instanceof TypeVariable) {
+        if (_dataType instanceof WildcardType wildcardType && wildcardType.getUpperBounds().length > 0) {
+            return recursiveGetDBusType(_out, wildcardType.getUpperBounds()[0], _basic, _level);
+        } else if (_dataType instanceof TypeVariable) {
             _out[_level].append((char) ArgumentType.VARIANT);
         } else if (_dataType instanceof GenericArrayType gat) {
             _out[_level].append((char) ArgumentType.ARRAY);


### PR DESCRIPTION
This PR adds support to the marshaller for wildcard types (e.g. `Map<String, ? extends List<String>` -> `a{sas}`) which is needed because reflection in Kotlin transforms a `Map<String, List<String>>` into the former.

Closes #269