### PR TITLE
(feat): Add BusName and ObjectPath annotation support for core

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/BusName.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/BusName.java
@@ -1,0 +1,11 @@
+package org.freedesktop.dbus.annotations;
+
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface BusName {
+    String value();
+}

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/ObjectPath.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/ObjectPath.java
@@ -1,0 +1,10 @@
+package org.freedesktop.dbus.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface ObjectPath {
+    String value();
+}

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DBusConnection.java
@@ -5,6 +5,9 @@ import static org.freedesktop.dbus.utils.CommonRegexPattern.*;
 import org.freedesktop.dbus.DBusMatchRule;
 import org.freedesktop.dbus.RemoteInvocationHandler;
 import org.freedesktop.dbus.RemoteObject;
+import org.freedesktop.dbus.annotations.BusName;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.ObjectPath;
 import org.freedesktop.dbus.connections.AbstractConnection;
 import org.freedesktop.dbus.connections.IDisconnectAction;
 import org.freedesktop.dbus.connections.config.ReceivingServiceConfig;
@@ -453,6 +456,27 @@ public final class DBusConnection extends AbstractConnection {
     public <I extends DBusInterface> I getRemoteObject(String _busname, String _objectpath, Class<I> _type)
             throws DBusException {
         return getRemoteObject(_busname, _objectpath, _type, true);
+    }
+
+    public <I extends DBusInterface> I getRemoteObject(Class<I> type) throws DBusException{
+        BusName[] busNameTypes
+                = type.getAnnotationsByType(BusName.class);
+        if(busNameTypes.length == 0){
+            throw new DBusException("No BusName annotation found on class " + type.getName());
+        }
+        if(busNameTypes.length > 1){
+            throw new DBusException("Multiple BusName annotations found on class " + type.getName());
+        }
+        String busName= busNameTypes[0].value();
+        ObjectPath[] objectPathTypes = type.getAnnotationsByType(ObjectPath.class);
+        if(objectPathTypes.length == 0){
+            throw new DBusException("No DBusInterfaceName annotation found on class " + type.getName());
+        }
+        if(objectPathTypes.length > 1){
+            throw new DBusException("Multiple DBusInterfaceName annotations found on class " + type.getName());
+        }
+        String interfaceName = objectPathTypes[0].value();
+        return getRemoteObject(busName, interfaceName, type);
     }
 
     /**


### PR DESCRIPTION
- Add BusName and ObjectPath annotations to mark interface bus names and object paths
- Implement annotation-based remote object retrieval in DBusConnection
- Add validation for annotation presence and uniqueness with improved error messages


then you can use like this:

```java


@DBusInterfaceName("org.ganesha.nfsd.exportmgr")
@BusName("org.ganesha.nfsd")
@ObjectPath("/org/ganesha/nfsd/ExportMgr")
public interface ExportMgr extends DBusInterface, Properties {
  String AddExport(String path, String expr);

  ShowExportResult ShowExports();

  /**
   * 使用配置文件添加导出
   *
   * @param expr 表达式
   * @param conf 配置文件
   * @return
   */
  String AddExportWithConf(String expr, String conf);

  void RemoveExport(UInt16 exportId);
} 
```

```java
		ExportMgr remoteObject = connection.getRemoteObject( ExportMgr.class);
```

It's very convenient to use.