### PR TITLE
minor code improvements

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/Container.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/Container.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -13,7 +14,7 @@ import java.util.stream.Collectors;
  * and holds common methods.
  */
 public abstract class Container {
-    private static final Map<Type, Type[]> TYPE_CACHE = new HashMap<>();
+    private static final Map<Type, Type[]> TYPE_CACHE = new ConcurrentHashMap<>();
     private Object[]                       parameters = null;
 
     Container() {

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/Marshalling.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/Marshalling.java
@@ -22,6 +22,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * Contains static methods for marshalling values.
  */
 public final class Marshalling {
+
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+    private static final Type[] EMPTY_TYPE_ARRAY = new Type[0];
+
     /** Used as initial and incremental size of StringBuffer array when resolving DBusTypes recursively. */
     private static final int INITIAL_BUFFER_SZ = 10;
 
@@ -289,7 +293,7 @@ public final class Marshalling {
                 for (Type t : ts) {
                     Collections.addAll(vs, recursiveGetDBusType(_out, t, false, _level + 1));
                 }
-                return vs.toArray(new String[0]);
+                return vs.toArray(EMPTY_STRING_ARRAY);
             } else {
                 throw new DBusException("Exporting non-exportable parameterized type " + _dataType);
             }
@@ -385,7 +389,7 @@ public final class Marshalling {
 
                     List<Type> contained = new ArrayList<>();
                     getJavaType(_dbusType.substring(idx + 1, structIdx - 1), contained, -1);
-                    _resultValue.add(new DBusStructType(contained.toArray(new Type[0])));
+                    _resultValue.add(new DBusStructType(contained.toArray(EMPTY_TYPE_ARRAY)));
                     idx = structIdx - 1; //-1 because j already points to the next signature char
                     break;
                 case ArgumentType.ARRAY:
@@ -577,7 +581,7 @@ public final class Marshalling {
         if (_type instanceof Class && ((Class<?>) _type).isArray() && ((Class<?>) _type).getComponentType().equals(Type.class) && parameter instanceof String) {
             List<Type> rv = new ArrayList<>();
             getJavaType((String) parameter, rv, -1);
-            parameter = rv.toArray(new Type[0]);
+            parameter = rv.toArray(EMPTY_TYPE_ARRAY);
         }
 
         // its an object path, get/create the proxy

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
@@ -45,56 +45,59 @@ public class RemoteInvocationHandler implements InvocationHandler {
 
     @Override
     public Object invoke(Object _proxy, Method _method, Object[] _args) throws Throwable {
-        if (_method.getName().equals("isRemote")) {
-            return true;
-        } else if (_method.getName().equals("getObjectPath")) {
-            return remote.getObjectPath();
-        } else if (_method.getName().equals("clone")) {
-            return null;
-        } else if (_method.getName().equals("equals")) {
-            try {
-                if (1 == _args.length) {
-                    return _args[0] != null && remote.equals(((RemoteInvocationHandler) Proxy.getInvocationHandler(_args[0])).remote);
+        switch (_method.getName()) {
+            case "isRemote":
+                return true;
+            case "getObjectPath":
+                return remote.getObjectPath();
+            case "clone":
+                return null;
+            case "equals":
+                try {
+                    if (1 == _args.length) {
+                        return _args[0] != null && remote.equals(((RemoteInvocationHandler) Proxy.getInvocationHandler(_args[0])).remote);
+                    }
+                } catch (IllegalArgumentException _exIa) {
+                    return Boolean.FALSE;
                 }
-            } catch (IllegalArgumentException _exIa) {
-                return Boolean.FALSE;
-            }
-        } else if (_method.getName().equals("finalize")) {
-            return null;
-        } else if (_method.getName().equals("getClass")) {
-            return DBusInterface.class;
-        } else if (_method.getName().equals("hashCode")) {
-            return remote.hashCode();
-        } else if (_method.getName().equals("notify")) {
-            synchronized (remote) {
-                remote.notify();
-            }
-            return null;
-        } else if (_method.getName().equals("notifyAll")) {
-            synchronized (remote) {
-                remote.notifyAll();
-            }
-            return null;
-        } else if (_method.getName().equals("wait")) {
-            synchronized (remote) {
-                if (_args.length == 0) {
-                    remote.wait();
-                } else if (_args.length == 1 && _args[0] instanceof Long l) {
-                    remote.wait(l);
-                } else if (_args.length == 2 && _args[0] instanceof Long l && _args[1] instanceof Integer i) {
-                    remote.wait(l, i);
+            case "finalize":
+                return null;
+            case "getClass":
+                return DBusInterface.class;
+            case "hashCode":
+                return remote.hashCode();
+            case "notify":
+                synchronized (remote) {
+                    remote.notify();
                 }
-                if (_args.length <= 2) {
-                    return null;
+                return null;
+            case "notifyAll":
+                synchronized (remote) {
+                    remote.notifyAll();
                 }
-            }
-        } else if (_method.getName().equals("toString")) {
-            return remote.toString();
-        } else if (_method.isAnnotationPresent(DBusBoundProperty.class)) {
-            return PropRefRemoteHandler.handleDBusBoundProperty(conn, remote, _method, _args);
-        }
+                return null;
+            case "wait":
+                synchronized (remote) {
+                    if (_args.length == 0) {
+                        remote.wait();
+                    } else if (_args.length == 1 && _args[0] instanceof Long l) {
+                        remote.wait(l);
+                    } else if (_args.length == 2 && _args[0] instanceof Long l && _args[1] instanceof Integer i) {
+                        remote.wait(l, i);
+                    }
+                    if (_args.length <= 2) {
+                        return null;
+                    }
+                }
+            case "toString":
+                return remote.toString();
+            default:
+                if (_method.isAnnotationPresent(DBusBoundProperty.class)) {
+                    return PropRefRemoteHandler.handleDBusBoundProperty(conn, remote, _method, _args);
+                }
 
-        return executeRemoteMethod(remote, _method, conn, CALL_TYPE_SYNC, null, _args);
+                return executeRemoteMethod(remote, _method, conn, CALL_TYPE_SYNC, null, _args);
+        }
     }
 
     public static Object convertRV(Object[] _rp, Method _m, AbstractConnection _conn) throws DBusException {

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/bin/DBusDaemon.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/bin/DBusDaemon.java
@@ -48,6 +48,7 @@ public class DBusDaemon extends Thread implements Closeable {
 
     private static final String                                                 DBUS_BUSPATH    = "/org/freedesktop/DBus";
     private static final String                                                 DBUS_BUSNAME    = "org.freedesktop.DBus";
+    private static final String[]                                               EMPTY_STRING_ARRAY = new String[0];
 
     private static final Logger                                                 LOGGER          =
             LoggerFactory.getLogger(DBusDaemon.class);
@@ -458,7 +459,7 @@ public class DBusDaemon extends Thread implements Closeable {
         public String[] ListNames() {
             String[] ns;
             Set<String> nss = names.keySet();
-            ns = nss.toArray(new String[0]);
+            ns = nss.toArray(EMPTY_STRING_ARRAY);
             return ns;
         }
 

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/connections/impl/DirectConnection.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * </p>
  */
 public class DirectConnection extends AbstractConnection {
+    private static final Class[] EMPTY_CLASS_ARRAY = new Class[0];
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final String machineId;
 
@@ -86,7 +87,7 @@ public class DirectConnection extends AbstractConnection {
             }
 
             RemoteObject ro = new RemoteObject(null, _path, _type, false);
-            DBusInterface newi = (DBusInterface) Proxy.newProxyInstance(ifcs.get(0).getClassLoader(), ifcs.toArray(new Class[0]), new RemoteInvocationHandler(this, ro));
+            DBusInterface newi = (DBusInterface) Proxy.newProxyInstance(ifcs.get(0).getClassLoader(), ifcs.toArray(EMPTY_CLASS_ARRAY), new RemoteInvocationHandler(this, ro));
             getImportedObjects().put(newi, ro);
             return (T) newi;
         } catch (Exception _ex) {

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/PrimitiveUtils.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/utils/PrimitiveUtils.java
@@ -73,8 +73,6 @@ public final class PrimitiveUtils {
 
         if (_clz1 == _clz2) {
             return true;
-        } else if (_clz1.isPrimitive() && _clz2.isPrimitive() && _clz1 == _clz2) {
-            return true;
         } else if (_clz1.isPrimitive()) {
             Class<?> wrappedType = PRIMITIVE_TO_WRAPPER.get(_clz1);
             return wrappedType == _clz2;


### PR DESCRIPTION
This PR does minor code improvements, as follows:

- `Container.java`: Use a `ConcurrentHashMap` in the static cache, to ensure thread safty like `Marshalling.TYPE_CACHE` does.
- `Marshalling.java`, `DBusDaemon.java`, `DirectConnection.java`: Avoid creating empty arrays disposed after passing it to `toArray`.
- `PrimitiveUtils.java`: `_clz1 == _clz2` does match in line 74, the removed code is therefore not reachable
- `RemoteInvocationHandler.java`: use `switch (String)` instead of `if/else if`