### PR TITLE
Allow interaction authorization

### DIFF
--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/RemoteInvocationHandler.java
@@ -1,6 +1,7 @@
 package org.freedesktop.dbus;
 
 import org.freedesktop.dbus.annotations.DBusBoundProperty;
+import org.freedesktop.dbus.annotations.MethodAllowInteractiveAutorization;
 import org.freedesktop.dbus.annotations.MethodNoReply;
 import org.freedesktop.dbus.connections.AbstractConnection;
 import org.freedesktop.dbus.errors.NoReply;
@@ -195,6 +196,9 @@ public class RemoteInvocationHandler implements InvocationHandler {
         }
         if (_m.isAnnotationPresent(MethodNoReply.class)) {
             flags |= Flags.NO_REPLY_EXPECTED;
+        }
+        if (_m.isAnnotationPresent(MethodAllowInteractiveAutorization.class)) {
+            flags |= Flags.ALLOW_INTERACTIVE_AUTHORIZATION;
         }
         try {
             String name = DBusNamingUtil.getMethodName(_m);

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/MethodAllowInteractiveAutorization.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/annotations/MethodAllowInteractiveAutorization.java
@@ -1,0 +1,22 @@
+package org.freedesktop.dbus.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Methods allow interactive autorization
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@DBusInterfaceName("org.freedesktop.DBus.Method.AllowInteractiveAutorization")
+public @interface MethodAllowInteractiveAutorization {
+
+    /**
+     * Annotation value, true by default
+     *
+     * @return true when a method allow interactive autorization, false otherwise
+     */
+    boolean value() default true;
+}

--- a/dbus-java-core/src/main/java/org/freedesktop/dbus/messages/constants/Flags.java
+++ b/dbus-java-core/src/main/java/org/freedesktop/dbus/messages/constants/Flags.java
@@ -5,9 +5,10 @@ package org.freedesktop.dbus.messages.constants;
  * @since 5.0.0 - 2023-10-23
  */
 public final class Flags {
-    public static final byte NO_REPLY_EXPECTED = 0x01;
-    public static final byte NO_AUTO_START     = 0x02;
-    public static final byte ASYNC             = 0x40;
+    public static final byte NO_REPLY_EXPECTED                = 0x01;
+    public static final byte NO_AUTO_START                    = 0x02;
+    public static final byte ALLOW_INTERACTIVE_AUTHORIZATION  = 0x04;
+    public static final byte ASYNC                            = 0x40;
 
     private Flags() {
 

--- a/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/systemd/SystemdUnitsManagment.java
+++ b/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/systemd/SystemdUnitsManagment.java
@@ -51,7 +51,7 @@ public final class SystemdUnitsManagment {
                 SimpleSystemdManagerInterface.class
             );
 
-            System.out.println(sysdManager.stopUnit("httpd.service", "replace"));
+            System.out.println(sysdManager.stopUnit("your.service", "replace"));
 
         }
     }

--- a/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/systemd/SystemdUnitsManagment.java
+++ b/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/systemd/SystemdUnitsManagment.java
@@ -1,0 +1,70 @@
+package com.github.hypfvieh.dbus.examples.systemd;
+
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusMemberName;
+import org.freedesktop.dbus.annotations.MethodAllowInteractiveAutorization;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+
+/**
+ * Demonstrates how to use {@link MethodAllowInteractiveAutorization} to call
+ * systemd methods that may require Polkit authentication.<br>
+ * <p>
+ * In this example, we connect to the systemd Manager interface and call
+ * {@code StartUnit} or {@code StopUnit}. These methods typically require
+ * administrative privileges and may trigger an interactive Polkit dialog
+ * when called by an unprivileged user.
+ * </p>
+ * <p>
+ * The {@link MethodAllowInteractiveAutorization} annotation tells the D-Bus
+ * daemon that the caller is prepared to wait for interactive authorization
+ * (e.g., password prompt). Without this annotation, such calls may fail
+ * with a {@code DBusExecutionException: Interactive authentication required}.
+ * </p>
+ * <p>
+ * The interface {@link SimpleSystemdManagerInterface} uses the
+ * {@link DBusInterfaceName} annotation to specify the D-Bus interface name,
+ * and {@link DBusMemberName} to map Java method names to D-Bus method names.
+ * </p>
+ *
+ * @author unfamiliarS
+ *
+ * @see MethodAllowInteractiveAutorization
+ * @see DBusInterfaceName
+ * @see DBusMemberName
+ *
+ * @since 2026-07-15
+ */
+public final class SystemdUnitsManagment {
+    private SystemdUnitsManagment() {}
+
+    public static void main(String[] _args) throws DBusException {
+
+        try (DBusConnection sessionConnection = DBusConnectionBuilder.forSystemBus().build()) {
+
+            SimpleSystemdManagerInterface sysdManager = sessionConnection.getRemoteObject(
+                "org.freedesktop.systemd1",
+                "/org/freedesktop/systemd1",
+                SimpleSystemdManagerInterface.class
+            );
+
+            System.out.println(sysdManager.stopUnit("httpd.service", "replace"));
+
+        }
+    }
+
+    @DBusInterfaceName("org.freedesktop.systemd1.Manager")
+    interface SimpleSystemdManagerInterface extends DBusInterface {
+
+        @DBusMemberName(value = "StartUnit")
+        @MethodAllowInteractiveAutorization
+        DBusPath startUnit(String _name, String _mode);
+
+        @DBusMemberName(value = "StopUnit")
+        @MethodAllowInteractiveAutorization
+        DBusPath stopUnit(String _name, String _mode);
+    }
+}

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/MethodTest.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/MethodTest.java
@@ -2,12 +2,15 @@ package org.freedesktop.dbus.test;
 
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.Marshalling;
+import org.freedesktop.dbus.annotations.MethodAllowInteractiveAutorization;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.test.helper.SampleException;
 import org.freedesktop.dbus.test.helper.callbacks.handler.CallbackHandlerImpl;
+import org.freedesktop.dbus.test.helper.interfaces.RemoteInteractiveInterface;
 import org.freedesktop.dbus.test.helper.interfaces.SampleRemoteInterface;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -94,5 +97,30 @@ public class MethodTest extends AbstractDBusBaseTest {
 
         assertEquals(0, cbWhichWorks.getTestErrorCalls());
         assertEquals(1, cbWhichThrows.getTestErrorCalls());
+    }
+
+    @Test
+    public void testInteractiveAutorizationFlag() throws DBusException, NoSuchMethodException {
+        logger.debug("Testing @MethodAllowInteractiveAutorization");
+
+        // Test if annotation is present
+        Method method = RemoteInteractiveInterface.class.getMethod("interactiveMethod");
+        assertTrue(method.isAnnotationPresent(MethodAllowInteractiveAutorization.class),
+                "Method should have @MethodAllowInteractiveAutorization annotation");
+
+        // Test if annotation value is true
+        MethodAllowInteractiveAutorization annotation =
+            method.getAnnotation(MethodAllowInteractiveAutorization.class);
+        assertTrue(annotation.value(), "Default value should be true");
+
+        RemoteInteractiveInterface tri = (RemoteInteractiveInterface) clientconn.getPeerRemoteObject(getTestBusName(), getTestObjectPath());
+
+        // Try to invoke annotated method
+        try {
+            tri.interactiveMethod();
+            logger.debug("Method with @MethodAllowInteractiveAutorization called successfully");
+        } catch (Exception _ex) {
+            fail("Method with @MethodAllowInteractiveAutorization should not throw: " + _ex.getMessage());
+        }
     }
 }

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/SampleClass.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/SampleClass.java
@@ -10,6 +10,7 @@ import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.DBusInterface;
 import org.freedesktop.dbus.interfaces.Properties;
+import org.freedesktop.dbus.test.helper.interfaces.RemoteInteractiveInterface;
 import org.freedesktop.dbus.test.helper.interfaces.SampleNewInterface;
 import org.freedesktop.dbus.test.helper.interfaces.SampleRemoteInterface;
 import org.freedesktop.dbus.test.helper.interfaces.SampleRemoteInterface2;
@@ -26,7 +27,7 @@ import java.lang.reflect.Type;
 import java.util.*;
 
 @SuppressWarnings({"checkstyle:methodname"})
-public class SampleClass implements SampleRemoteInterface, SampleRemoteInterface2, SampleRemoteInterfaceEnum, Properties {
+public class SampleClass implements SampleRemoteInterface, SampleRemoteInterface2, SampleRemoteInterfaceEnum, Properties, RemoteInteractiveInterface {
 
     private final transient Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -90,6 +91,11 @@ public class SampleClass implements SampleRemoteInterface, SampleRemoteInterface
         } catch (InterruptedException _ex) {
         }
         logger.debug("Done sleeping.");
+    }
+
+    @Override
+    public void interactiveMethod() {
+        logger.debug("testInteractiveMethod called");
     }
 
     @Override

--- a/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/interfaces/RemoteInteractiveInterface.java
+++ b/dbus-java-tests/src/test/java/org/freedesktop/dbus/test/helper/interfaces/RemoteInteractiveInterface.java
@@ -1,0 +1,13 @@
+package org.freedesktop.dbus.test.helper.interfaces;
+
+import org.freedesktop.dbus.annotations.MethodAllowInteractiveAutorization;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.constants.Flags;
+
+/**
+ * Interface for testing {@link Flags#ALLOW_INTERACTIVE_AUTHORIZATION} flag.
+ */
+public interface RemoteInteractiveInterface extends DBusInterface {
+    @MethodAllowInteractiveAutorization
+    void interactiveMethod();
+}

--- a/src/site/markdown/remote-objects.md
+++ b/src/site/markdown/remote-objects.md
@@ -41,3 +41,34 @@ data is handled completely transparently.
 *Note:* The one issue that this does have is that the method calls are all
 blocking.  If the remote application has an issue, your application will stall
 until the method call times out.
+
+## Controlling Remote Method Call Behavior
+
+When calling remote D-Bus methods, you can influence how the call is handled by using annotations on the methods declared in your interface. These annotations allow you to set specific flags in the D-Bus message header.
+
+### Available Annotations
+
+*   **`@MethodNoReply`**
+    Method does not return replies or error replies, even if it is of a type that can have a reply.
+    ```java
+    @MethodNoReply
+    int add(int _a, int _b);
+    ```
+    Returns null even for the arguments from the example above.
+
+*   **`@MethodAllowInteractiveAutorization`**
+    This annotation signals the D-Bus daemon that the caller is ready to wait for interactive authorization (e.g., Polkit password prompts). It is useful when unprivileged code calls a privileged method, and an authorization framework that supports user interaction is in place.
+
+    As an example, let's take a call to a remote Systemd manager object method that requires elevated privileges to execute. Use [the code from the example](https://github.com/hypfvieh/dbus-java/tree/master/dbus-java-examples/src/main/java/com/github/hypfvieh/dbus/examples/systemd/SystemdUnitsManagment.java):
+    ```java
+    @DBusMemberName(value = "StartUnit")
+    @MethodAllowInteractiveAutorization
+    DBusPath startUnit(String name, String mode);
+
+    @DBusMemberName(value = "StopUnit")
+    @MethodAllowInteractiveAutorization
+    DBusPath stopUnit(String name, String mode);
+    ```
+    After calling the method, the user authorization window is guaranteed to be displayed if it needed.
+
+*Note:* More info about this you can find [here](https://dbus.freedesktop.org/doc/dbus-specification.html).


### PR DESCRIPTION
I'm using this library to create a GUI shell for managing systemd daemons, and some issues emerged during development. When sending a DBus request to execute file system commands (such as EnableUnitFiles and DisableUnitFiles, see the systemd DBus API for more details: https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.systemd1.html), the graphical user login window wouldn't appear, and an error would immediately be thrown:
```
org.freedesktop.dbus.exceptions.DBusExecutionException: Interactive authentication required.
        at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
        at org.freedesktop.dbus.messages.Error.getException(Error.java:113)
        at org.freedesktop.dbus.messages.Error.throwException(Error.java:138)
        at org.freedesktop.dbus.RemoteInvocationHandler.executeRemoteMethod(RemoteInvocationHandler.java:241)
        at org.freedesktop.dbus.RemoteInvocationHandler.executeRemoteMethod(RemoteInvocationHandler.java:254)
        at org.freedesktop.dbus.RemoteInvocationHandler.executeRemoteMethod(RemoteInvocationHandler.java:156)
        at org.freedesktop.dbus.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:99)
        at jdk.proxy1/jdk.proxy1.$Proxy21.disableUnitFiles(Unknown Source)
        at de.thjom.java.systemd.Manager.disableUnitFiles(Manager.java:200)
        at com.shavarushka.models.sysd_commands.commands.DisableUnitCommand.execute(DisableUnitCommand.java:67)
        at com.shavarushka.controllers.SysdActionsC.lambda$18(SysdActionsC.java:199)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

I read the DBus specification (https://dbus.freedesktop.org/doc/dbus-specification.html) and found a solution: add the 0x4 byte to the message header, which tells the receiving end to wait for authorization.

The code I'm proposing allows you to mark DBus methods in your client code that should allow interactive authorization. For example, here's how I use it:
```
    @DBusMemberName(value = "DisableUnitFiles")
    @MethodAllowInteractiveAutorization
    List<UnitFileChange> disableUnitFiles(List<String> names, boolean runtime);

    @DBusMemberName(value = "EnableUnitFiles")
    @MethodAllowInteractiveAutorization(value = true)
    Pair<Boolean, List<UnitFileChange>> enableUnitFiles(List<String> names, boolean runtime, boolean force);
```