### PR TITLE
Maven and IDE tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 .project
 *.iml
 
-.idea
+.idea/*
+!.idea/icon.svg
 build
 
 dbus-java-osgi/META-INF

--- a/.idea/icon.svg
+++ b/.idea/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#2c5aa0"/>
+  <path stroke="#fff" stroke-width="38.4" d="M256 96 128 224m128-128 128 128M128 224l128 128m128-128-128 128M128 224h256m-128 128v80"/>
+  <circle cx="256" cy="96" r="44.8" fill="orange"/>
+  <circle cx="128" cy="224" r="44.8" fill="#fff"/>
+  <circle cx="384" cy="224" r="44.8" fill="#fff"/>
+  <circle cx="256" cy="352" r="44.8" fill="#fff"/>
+  <circle cx="256" cy="432" r="38.4" fill="orange"/>
+</svg>

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,6 @@
         <!-- Build properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
 
         <parentDir>${maven.multiModuleProjectDirectory}</parentDir>
         <project.build.outputTimestamp>2025-12-21T13:12:42Z</project.build.outputTimestamp>
@@ -248,17 +246,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${mvn.maven.compiler.plugin}</version>
-                    <executions>
-                        <execution>
-                            <id>compile</id>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                            <configuration>
-                                <release>${maven.compiler.source}</release>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -541,6 +541,11 @@
         <tag>HEAD</tag>
     </scm>
 
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/hypfvieh/dbus-java/issues</url>
+    </issueManagement>
+
     <licenses>
         <license>
            <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     </modules>
 
     <build>
+        <defaultGoal>clean verify</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <!-- Dependency versions -->
         <junit6.version>6.0.1</junit6.version>
-        <pmd.version>7.22.0</pmd.version>
+        <pmd.version>7.27.0</pmd.version>
         <checkstyle.version>12.3.0</checkstyle.version>
         <logback.version>1.5.35</logback.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -33,7 +33,7 @@
         <mvn.maven.clean.plugin>3.5.0</mvn.maven.clean.plugin>
         <mvn.maven.compiler.plugin>3.14.1</mvn.maven.compiler.plugin>
         <mvn.maven.deploy.plugin>3.1.4</mvn.maven.deploy.plugin>
-        <mvn.maven.enforcer.plugin>3.6.2</mvn.maven.enforcer.plugin>
+        <mvn.maven.enforcer.plugin>3.6.3</mvn.maven.enforcer.plugin>
         <mvn.maven.gpg.plugin>3.2.8</mvn.maven.gpg.plugin>
         <mvn.maven.install.plugin>3.1.4</mvn.maven.install.plugin>
         <mvn.maven.jar.plugin>3.5.0</mvn.maven.jar.plugin>
@@ -46,8 +46,8 @@
         <mvn.maven.source.plugin>3.4.0</mvn.maven.source.plugin>
         <mvn.maven.surefire.plugin>3.5.4</mvn.maven.surefire.plugin>
         <mvn.sonar.maven.plugin>5.5.0.6356</mvn.sonar.maven.plugin>
-        <mvn.versions.maven.plugin>2.20.1</mvn.versions.maven.plugin>
-        <mvn.centralpublishing.plugin.version>0.9.0</mvn.centralpublishing.plugin.version>
+        <mvn.versions.maven.plugin>2.21.0</mvn.versions.maven.plugin>
+        <mvn.centralpublishing.plugin.version>0.11.0</mvn.centralpublishing.plugin.version>
 
         <!-- Code analysis -->
         <check.skip-javadoc>false</check.skip-javadoc>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
                                     <requireOS>
                                         <family>unix</family>
                                     </requireOS>
+                                    <banDuplicatePomDependencyVersions/>
                                 </rules>
                             </configuration>
                         </execution>


### PR DESCRIPTION
## Summary
- Update build plugin versions
- Add issueManagement pointing to GitHub Issues
- Add banDuplicatePomDependencyVersions enforcer rule
- Remove redundant compiler.source/target properties
- Add custom IntelliJ IDEA project icon
- Set Maven defaultGoal to 'clean verify'

## Test plan
- [x] `mvn clean verify` runs successfully